### PR TITLE
Delete appliance vm in detach l2network from cluster

### DIFF
--- a/test/src/test/java/org/zstack/test/virtualrouter/vyos/TestVyosMigrateAfterL2NetworkDetach.java
+++ b/test/src/test/java/org/zstack/test/virtualrouter/vyos/TestVyosMigrateAfterL2NetworkDetach.java
@@ -9,27 +9,27 @@ import org.zstack.core.db.DatabaseFacade;
 import org.zstack.header.identity.SessionInventory;
 import org.zstack.header.network.l3.L3NetworkInventory;
 import org.zstack.header.vm.VmInstanceInventory;
-import org.zstack.network.service.portforwarding.PortForwardingProtocolType;
-import org.zstack.network.service.portforwarding.PortForwardingRuleInventory;
-import org.zstack.network.service.vip.VipInventory;
 import org.zstack.network.service.virtualrouter.VirtualRouterVmVO;
-import org.zstack.network.service.virtualrouter.portforwarding.PortForwardingRuleTO;
 import org.zstack.simulator.appliancevm.ApplianceVmSimulatorConfig;
 import org.zstack.simulator.virtualrouter.VirtualRouterSimulatorConfig;
-import org.zstack.test.*;
+import org.zstack.test.Api;
+import org.zstack.test.ApiSenderException;
+import org.zstack.test.DBUtil;
+import org.zstack.test.WebBeanConstructor;
 import org.zstack.test.deployer.Deployer;
-import org.zstack.test.virtualrouter.PortForwardingRuleTestValidator;
-import org.zstack.test.virtualrouter.VipTestValidator;
+import org.zstack.utils.Utils;
+import org.zstack.utils.logging.CLogger;
 
 /**
  * @author WeiW
  * @condition use vyos provider
  * <p>
  * 1. detach a l2network from a cluster
- * 2. check the router delete for no other cluster
+ * 2. check the router migrate to another cluster
  * @test confirm port forwarding rules on vm are correct
  */
-public class TestVyosAfterL2NetworkDetach {
+public class TestVyosMigrateAfterL2NetworkDetach {
+    private static final CLogger logger = Utils.getLogger(TestVyosMigrateAfterL2NetworkDetach.class);
     Deployer deployer;
     Api api;
     ComponentLoader loader;
@@ -43,7 +43,7 @@ public class TestVyosAfterL2NetworkDetach {
     public void setUp() throws Exception {
         DBUtil.reDeployDB();
         WebBeanConstructor con = new WebBeanConstructor();
-        deployer = new Deployer("deployerXml/virtualRouter/TestVyosAfterL2NetworkDetach.xml", con);
+        deployer = new Deployer("deployerXml/virtualRouter/TestVyosMigrateAfterL2NetworkDetach.xml", con);
         deployer.addSpringConfig("VirtualRouter.xml");
         deployer.addSpringConfig("VirtualRouterSimulator.xml");
         deployer.addSpringConfig("KVMRelated.xml");
@@ -62,15 +62,14 @@ public class TestVyosAfterL2NetworkDetach {
 
     @Test
     public void test() throws ApiSenderException {
-        L3NetworkInventory publicNw = deployer.l3Networks.get("PublicNetwork");
         String l2Uuid = deployer.l2Networks.get("TestL2Network").getUuid();
-        String clusterUuid = deployer.clusters.get("Cluster1").getUuid();
-        VmInstanceInventory vm = deployer.vms.get("TestVm");
         VirtualRouterVmVO vr = dbf.listAll(VirtualRouterVmVO.class).get(0);
-        Assert.assertNotNull(vr);
+        String preClusterUuid = vr.getClusterUuid();
 
-        api.detachL2NetworkFromCluster(l2Uuid, clusterUuid);
+        api.detachL2NetworkFromCluster(l2Uuid, preClusterUuid);
+        vr = dbf.listAll(VirtualRouterVmVO.class).get(0);
+        String afterClusterUuid = vr.getClusterUuid();
 
-        Assert.assertTrue(dbf.listAll(VirtualRouterVmVO.class).isEmpty());
+        Assert.assertNotSame(preClusterUuid, afterClusterUuid);
     }
 }

--- a/test/src/test/resources/deployerXml/virtualRouter/TestVyosMigrateAfterL2NetworkDetach.xml
+++ b/test/src/test/resources/deployerXml/virtualRouter/TestVyosMigrateAfterL2NetworkDetach.xml
@@ -1,0 +1,129 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<deployerConfig xmlns="http://zstack.org/schema/zstack">
+
+    <instanceOfferings>
+        <virtualRouterOffering name="virtualRouterOffering"
+            isDefault="true">
+            <zoneRef>Zone1</zoneRef>
+            <managementL3NetworkRef>PublicNetwork</managementL3NetworkRef>
+            <publicL3NetworkRef>PublicNetwork</publicL3NetworkRef>
+            <imageRef>TestImage</imageRef>
+        </virtualRouterOffering>
+
+        <instanceOffering name="TestInstanceOffering"
+            description="Test" memoryCapacity="3G" cpuNum="1" cpuSpeed="3000" />
+    </instanceOfferings>
+
+    <backupStorages>
+        <sftpBackupStorage name="sftp" description="Test"
+            url="nfs://test" />
+    </backupStorages>
+
+    <images>
+        <image name="TestImage" description="Test">
+            <backupStorageRef>sftp</backupStorageRef>
+        </image>
+    </images>
+
+    <vm>
+        <userVm name="TestVm" description="Test">
+            <imageRef>TestImage</imageRef>
+            <instanceOfferingRef>TestInstanceOffering</instanceOfferingRef>
+            <l3NetworkRef>GuestNetwork</l3NetworkRef>
+        </userVm>
+    </vm>
+
+    <securityGroups>
+        <securityGroup name="test">
+            <l3NetworkRef>GuestNetwork</l3NetworkRef>
+            <rule>
+                <type>Ingress</type>
+                <protocol>TCP</protocol>
+                <startPort>22</startPort>
+                <endPort>100</endPort>
+                <allowedCidr>0.0.0.0/0</allowedCidr>
+            </rule>
+            <rule>
+                <type>Ingress</type>
+                <protocol>UDP</protocol>
+                <startPort>10</startPort>
+                <endPort>10</endPort>
+                <allowedCidr>192.168.0.1/0</allowedCidr>
+            </rule>
+        </securityGroup>
+    </securityGroups>
+
+    <portForwardings>
+        <portForwarding>
+            <name>pfRule1</name>
+            <publicL3NetworkRef>PublicNetwork</publicL3NetworkRef>
+            <privateL3NetworkRef>GuestNetwork</privateL3NetworkRef>
+            <vmRef>TestVm</vmRef>
+            <publicPortStart>22</publicPortStart>
+            <publicPortEnd>100</publicPortEnd>
+            <privatePortStart>22</privatePortStart>
+            <privatePortEnd>100</privatePortEnd>
+            <allowedCidr>77.10.3.1/24</allowedCidr>
+            <protocolType>TCP</protocolType>
+        </portForwarding>
+    </portForwardings>
+    
+    <zones>
+        <zone name="Zone1" description="Test">
+            <clusters>
+                <cluster name="Cluster1" description="Test" hypervisorType="KVM">
+                    <hosts>
+                        <kvmHost name="host1" description="Test" managementIp="127.0.0.1"
+                            memoryCapacity="64G" cpuNum="32" cpuSpeed="2600" />
+                    </hosts>
+                    <primaryStorageRef>nfs</primaryStorageRef>
+                    <l2NetworkRef>TestL2Network</l2NetworkRef>
+                </cluster>
+
+                <cluster name="Cluster2" description="Test" hypervisorType="KVM">
+                    <hosts>
+                        <kvmHost name="host2" description="Test" managementIp="127.0.0.2"
+                            memoryCapacity="64G" cpuNum="32" cpuSpeed="2600" />
+                    </hosts>
+                    <primaryStorageRef>nfs</primaryStorageRef>
+                    <l2NetworkRef>TestL2Network</l2NetworkRef>
+                </cluster>
+            </clusters>
+
+            <l2Networks>
+                <l2NoVlanNetwork name="TestL2Network" description="Test"
+                    physicalInterface="eth0">
+                    <l3Networks>
+                        <l3BasicNetwork name="PublicNetwork" description="Test">
+                            <ipRange name="TestIpRange" description="Test" startIp="192.168.1.10"
+                                endIp="192.168.1.100" gateway="192.168.1.1" netmask="255.255.255.0" />
+                        </l3BasicNetwork>
+
+                        <l3BasicNetwork name="GuestNetwork" description="Test">
+                            <ipRange name="TestIpRange" description="Test" startIp="10.10.2.100"
+                                endIp="10.20.2.200" gateway="10.10.2.1" netmask="255.0.0.0" />
+
+                            <networkService provider="vrouter">
+                                <serviceType>PortForwarding</serviceType>
+                                <serviceType>SNAT</serviceType>
+                                <serviceType>DHCP</serviceType>
+                                <serviceType>DNS</serviceType>
+                            </networkService>
+
+                            <networkService provider="SecurityGroup">
+                                <serviceType>SecurityGroup</serviceType>
+                            </networkService>
+                        </l3BasicNetwork>
+
+                    </l3Networks>
+                </l2NoVlanNetwork>
+            </l2Networks>
+
+            <backupStorageRef>sftp</backupStorageRef>
+            <primaryStorages>
+                <nfsPrimaryStorage name="nfs" description="Test"
+                    totalCapacity="5T" url="nfs://test" />
+            </primaryStorages>
+        </zone>
+    </zones>
+</deployerConfig>


### PR DESCRIPTION
If appliance vm migrate failed in detach l2network from cluster,
change behavior from stop vm to delete this vm.

TestCase: see TestVyosAfterL2NetworkDetach
which commited in zstackio/zstack/pull/554

For zstackio/issues#1800
For zstackio/issues#1689
For zstackio/issues#1826
Partially zstackio/issues#1539