### PR TITLE
allow to attach ISO to VM when PS is disabled

### DIFF
--- a/conf/serviceConfig/vmInstance.xml
+++ b/conf/serviceConfig/vmInstance.xml
@@ -79,6 +79,8 @@
     </message>
     <message>
         <name>org.zstack.header.vm.APIAttachIsoToVmInstanceMsg</name>
+        <interceptor>PrimaryStorageApiInterceptor</interceptor>
+        <interceptor>VmInstanceApiInterceptor</interceptor>
     </message>
     <message>
         <name>org.zstack.header.vm.APIDetachIsoFromVmInstanceMsg</name>

--- a/storage/src/main/java/org/zstack/storage/primary/PrimaryStorageBase.java
+++ b/storage/src/main/java/org/zstack/storage/primary/PrimaryStorageBase.java
@@ -179,6 +179,28 @@ public abstract class PrimaryStorageBase extends AbstractPrimaryStorage {
         }
     }
 
+    protected void checkIfIsoExistInDisabledPrimaryStorage(DownloadIsoToPrimaryStorageMsg msg){
+        logger.debug("check if ISO exist in disabled primary storage");
+        if(self.getState() == PrimaryStorageState.Enabled){
+            logger.debug("PS is enabled");
+            return ;
+        }
+        String isoUuid = msg.getIsoSpec().getInventory().getUuid();
+
+        SimpleQuery<ImageCacheVO> q = dbf.createQuery(ImageCacheVO.class);
+        q.select(ImageCacheVO_.installUrl);
+        q.add(ImageCacheVO_.primaryStorageUuid, Op.EQ, self.getUuid());
+        q.add(ImageCacheVO_.imageUuid, Op.EQ, isoUuid);
+        String fullPath = q.findValue();
+        if( fullPath == null){
+            logger.debug("iso not existing");
+            throw new OperationFailureException(errf.stringToOperationError(
+                    String.format("cannot attach ISO to a primary storage[uuid:%s] which is not 'enabled'",
+                            msg.getPrimaryStorageUuid())));
+        }
+        logger.debug("check pass");
+    }
+
     private void forbidOperationWhenPrimaryStorageDisable(String primaryStorageState) {
         if (primaryStorageState.equals(PrimaryStorageState.Disabled.toString())) {
             logger.debug("checking primary storage status whether Disabled");
@@ -230,6 +252,8 @@ public abstract class PrimaryStorageBase extends AbstractPrimaryStorage {
         } else if (msg instanceof DeleteSnapshotOnPrimaryStorageMsg) {
             forbidOperationWhenPrimaryStorageMaintenance(self.getState().toString());
         } else if (msg instanceof RevertVolumeFromSnapshotOnPrimaryStorageMsg) {
+            forbidOperationWhenPrimaryStorageMaintenance(self.getState().toString());
+        } else if (msg instanceof DownloadIsoToPrimaryStorageMsg) {
             forbidOperationWhenPrimaryStorageMaintenance(self.getState().toString());
         } else if (msg instanceof ReInitRootVolumeFromTemplateOnPrimaryStorageMsg) {
             forbidOperationWhenPrimaryStorageMaintenance(self.getState().toString());
@@ -332,6 +356,7 @@ public abstract class PrimaryStorageBase extends AbstractPrimaryStorage {
 
     private void handleBase(DownloadIsoToPrimaryStorageMsg msg) {
         checkIfBackupStorageAttachedToMyZone(msg.getIsoSpec().getSelectedBackupStorage().getBackupStorageUuid());
+        checkIfIsoExistInDisabledPrimaryStorage(msg);
         handle(msg);
     }
 

--- a/test/src/test/groovy/org/zstack/test/integration/storage/CephEnv.groovy
+++ b/test/src/test/groovy/org/zstack/test/integration/storage/CephEnv.groovy
@@ -1,0 +1,124 @@
+package org.zstack.test.integration.storage
+
+import org.bouncycastle.jce.provider.symmetric.TEA
+import org.zstack.header.network.service.NetworkServiceType
+import org.zstack.network.service.eip.EipConstant
+import org.zstack.network.service.flat.FlatNetworkServiceConstant
+import org.zstack.network.service.userdata.UserdataConstant
+import org.zstack.test.network.TestAcquireIp
+import org.zstack.testlib.EnvSpec
+import org.zstack.testlib.Test
+import org.zstack.utils.data.SizeUnit
+
+/**
+ * Created by Administrator on 2017-03-01.
+ */
+class CephEnv {
+    def DOC = """
+use:
+1. Ceph primary storage
+"""
+
+
+    static EnvSpec CephStorageOneVmEnv(){
+        return Test.makeEnv {
+            instanceOffering {
+                name = "instanceOffering"
+                memory = SizeUnit.GIGABYTE.toByte(8)
+                cpu = 4
+                }
+            diskOffering {
+                name = "diskOffering"
+                diskSize = SizeUnit.GIGABYTE.toByte(20)
+                }
+            zone{
+                name = "zone"
+                cluster {
+                    name = "test-cluster"
+                    hypervisorType = "KVM"
+
+                    kvm {
+                        name = "ceph-mon"
+                        managementIp = "localhost"
+                        username = "root"
+                        password = "password"
+                        usedMem = 1000
+                        totalCpu = 10
+                    }
+                    kvm {
+                        name = "host"
+                        username = "root"
+                        password = "password"
+                        usedMem = 1000
+                        totalCpu = 10
+                    }
+
+                    attachPrimaryStorage("ceph-pri")
+                    attachL2Network("l2")
+                }
+                l2NoVlanNetwork {
+                    name = "l2"
+                    physicalInterface = "eth0"
+
+                    l3Network {
+                        name = "l3"
+
+
+
+                        ip {
+                            startIp = "192.168.100.10"
+                            endIp = "192.168.100.100"
+                            netmask = "255.255.255.0"
+                            gateway = "192.168.100.1"
+                        }
+                    }
+                }
+
+                cephPrimaryStorage {
+                    name="ceph-pri"
+                    description="Test"
+                    totalCapacity = SizeUnit.GIGABYTE.toByte(100)
+                    availableCapacity= SizeUnit.GIGABYTE.toByte(100)
+                    url="ceph://pri"
+                    fsid="7ff218d9-f525-435f-8a40-3618d1772a64"
+                    monUrls=["root:password@localhost/?monPort=7777"]
+
+                }
+                
+
+                attachBackupStorage("ceph-bk")
+            }
+
+            cephBackupStorage {
+                name="ceph-bk"
+                description="Test"
+                totalCapacity = SizeUnit.GIGABYTE.toByte(100)
+                availableCapacity= SizeUnit.GIGABYTE.toByte(100)
+                url = "/bk"
+                fsid ="7ff218d9-f525-435f-8a40-3618d1772a64"
+                monUrls = ["root:password@localhost/?monPort=7777"]
+
+                image {
+                    name = "test-iso"
+                    url  = "http://zstack.org/download/test.iso"
+                }
+                image {
+                    name = "image"
+                    url  = "http://zstack.org/download/image.qcow2"
+                }
+            }
+
+            vm {
+                name = "test-vm"
+                useCluster("test-cluster")
+                useHost("host")
+                useL3Networks("l3")
+                useInstanceOffering("instanceOffering")
+                useRootDiskOffering("diskOffering")
+                useImage("image")
+
+            }
+
+        }
+    }
+}

--- a/test/src/test/groovy/org/zstack/test/integration/storage/StorageTest.groovy
+++ b/test/src/test/groovy/org/zstack/test/integration/storage/StorageTest.groovy
@@ -1,5 +1,7 @@
 package org.zstack.test.integration.storage
 
+import org.zstack.test.integration.storage.primary.ceph.AttachIsoCase
+import org.zstack.test.integration.storage.primary.ceph.AttachIsoCase2
 import org.zstack.test.integration.storage.primary.local.LocalStorageMigrateVolumeCase
 import org.zstack.test.integration.storage.primary.smp.SMPCapacityCase
 import org.zstack.testlib.SpringSpec
@@ -34,7 +36,9 @@ class StorageTest extends Test {
     void test() {
         runSubCases([
                 new LocalStorageMigrateVolumeCase(),
-                new SMPCapacityCase()
+                new SMPCapacityCase(),
+                new AttachIsoCase(),
+                new AttachIsoCase2()
         ])
     }
 }

--- a/test/src/test/groovy/org/zstack/test/integration/storage/primary/ceph/AttachIsoCase.groovy
+++ b/test/src/test/groovy/org/zstack/test/integration/storage/primary/ceph/AttachIsoCase.groovy
@@ -1,0 +1,175 @@
+package org.zstack.test.integration.storage.primary.ceph
+
+import org.springframework.http.HttpEntity
+import org.zstack.core.db.DatabaseFacade
+import org.zstack.core.db.SimpleQuery
+import org.zstack.header.storage.backup.BackupStorageStatus
+import org.zstack.header.storage.primary.ImageCacheVO
+import org.zstack.header.storage.primary.ImageCacheVO_
+import org.zstack.kvm.KVMAgentCommands
+import org.zstack.kvm.KVMConstant
+import org.zstack.kvm.KVMHost
+import org.zstack.sdk.AttachIsoToVmInstanceAction
+import org.zstack.storage.backup.BackupStorageBase
+import org.zstack.storage.ceph.backup.CephBackupStorageBase
+import org.zstack.storage.ceph.backup.CephBackupStorageMonBase
+import org.zstack.storage.ceph.primary.CephPrimaryStorageBase
+import org.zstack.header.storage.primary.PrimaryStorageState
+import org.zstack.header.storage.primary.PrimaryStorageVO
+import org.zstack.header.storage.backup.BackupStorageVO
+import org.zstack.storage.ceph.primary.CephPrimaryStorageMonBase
+import org.zstack.testlib.BackupStorageSpec
+import org.zstack.testlib.ImageSpec
+import org.zstack.testlib.EnvSpec
+import org.zstack.testlib.PrimaryStorageSpec
+import org.zstack.testlib.CephPrimaryStorageSpec
+import org.zstack.testlib.SubCase
+import org.zstack.testlib.Test
+import org.zstack.testlib.VmSpec
+import org.zstack.test.integration.storage.CephEnv
+import org.zstack.test.integration.storage.StorageTest
+
+import org.zstack.utils.gson.JSONObjectUtil
+import sun.awt.image.ImageCache;
+/**
+ * Created by xing5 on 2017/2/27.
+ */
+class AttachIsoCase extends SubCase {
+    EnvSpec env
+
+    @Override
+    void setup() {
+        useSpring(StorageTest.springSpec)
+    }
+
+    @Override
+    void environment() {
+        env = CephEnv.CephStorageOneVmEnv()
+    }
+
+    @Override
+    void test() {
+        env.create {
+            testAttachIsoToMaiteningPrimaryStorage()
+            testAttachIsoToDisabledCephStorageWhenIsoNotExisting()
+            testAttachIsoToDisabledCephStorageWhenIsoExisting()
+        }
+    }
+
+    @Override
+    void clean() {
+        env.delete()
+    }
+
+
+    void testAttachIsoToMaiteningPrimaryStorage() {
+        PrimaryStorageSpec primaryStorageSpec = env.specByName("ceph-pri") as PrimaryStorageSpec
+        BackupStorageSpec backupStorageSpec = env.specByName("ceph-bk") as BackupStorageSpec
+        VmSpec vmSpec = env.specByName("test-vm") as VmSpec
+        ImageSpec imageSpec = env.specByName("test-iso") as ImageSpec
+        DatabaseFacade dbf = bean(DatabaseFacade.class)
+
+        assert primaryStorageSpec.inventory.uuid
+        assert vmSpec.inventory.uuid
+        assert imageSpec.inventory.uuid
+        assert backupStorageSpec.inventory.uuid
+
+        PrimaryStorageVO psvo = dbf.findByUuid(primaryStorageSpec.inventory.uuid, PrimaryStorageVO.class)
+        psvo.state = PrimaryStorageState.Maintenance
+        dbf.updateAndRefresh(psvo)
+
+        assert dbf.findByUuid(primaryStorageSpec.inventory.uuid, PrimaryStorageVO.class).state == PrimaryStorageState.Maintenance
+
+        AttachIsoToVmInstanceAction a = new AttachIsoToVmInstanceAction()
+        a.isoUuid = imageSpec.inventory.uuid
+        a.vmInstanceUuid = vmSpec.inventory.uuid
+        a.sessionId = currentEnvSpec.session.uuid
+
+        AttachIsoToVmInstanceAction.Result res = a.call()
+        assert res.error.details == String.format("ISO cannot be attach to a vm whose primary storage[uuid:%s] is 'Maintenance'",
+                primaryStorageSpec.inventory.uuid)
+
+    }
+
+    void testAttachIsoToDisabledCephStorageWhenIsoNotExisting() {
+        PrimaryStorageSpec primaryStorageSpec = env.specByName("ceph-pri") as PrimaryStorageSpec
+        BackupStorageSpec backupStorageSpec = env.specByName("ceph-bk") as BackupStorageSpec
+        VmSpec vmSpec = env.specByName("test-vm") as VmSpec
+        ImageSpec imageSpec = env.specByName("test-iso") as ImageSpec
+        DatabaseFacade dbf = bean(DatabaseFacade.class)
+
+        assert primaryStorageSpec.inventory.uuid
+        assert vmSpec.inventory.uuid
+        assert imageSpec.inventory.uuid
+        assert backupStorageSpec.inventory.uuid
+
+        PrimaryStorageVO psvo = dbf.findByUuid(primaryStorageSpec.inventory.uuid, PrimaryStorageVO.class)
+        psvo.state = PrimaryStorageState.Disabled
+        dbf.updateAndRefresh(psvo)
+        assert dbf.findByUuid(primaryStorageSpec.inventory.uuid, PrimaryStorageVO.class).state == PrimaryStorageState.Disabled
+
+        AttachIsoToVmInstanceAction a = new AttachIsoToVmInstanceAction()
+        a.isoUuid = imageSpec.inventory.uuid
+        a.vmInstanceUuid = vmSpec.inventory.uuid
+        a.sessionId = currentEnvSpec.session.uuid
+        AttachIsoToVmInstanceAction.Result res = a.call()
+
+        assert res.error != null: "fail to attach iso ${res.error}"
+
+    }
+
+    void testAttachIsoToDisabledCephStorageWhenIsoExisting() {
+        PrimaryStorageSpec primaryStorageSpec = env.specByName("ceph-pri") as PrimaryStorageSpec
+        BackupStorageSpec backupStorageSpec = env.specByName("ceph-bk") as BackupStorageSpec
+        VmSpec vmSpec = env.specByName("test-vm") as VmSpec
+        ImageSpec imageSpec = env.specByName("test-iso") as ImageSpec
+        DatabaseFacade dbf = bean(DatabaseFacade.class)
+        assert primaryStorageSpec.inventory.uuid
+        assert vmSpec.inventory.uuid
+        assert imageSpec.inventory.uuid
+        assert backupStorageSpec.inventory.uuid
+
+
+        PrimaryStorageVO psvo = dbf.findByUuid(primaryStorageSpec.inventory.uuid, PrimaryStorageVO.class)
+        psvo.state = PrimaryStorageState.Enabled
+        dbf.updateAndRefresh(psvo)
+        assert dbf.findByUuid(primaryStorageSpec.inventory.uuid, PrimaryStorageVO.class).state == PrimaryStorageState.Enabled
+
+        attachIsoToVmInstance {
+            isoUuid = imageSpec.inventory.uuid
+            vmInstanceUuid = vmSpec.inventory.uuid
+            sessionId = currentEnvSpec.session.uuid
+        }
+        detachIsoFromVmInstance {
+            vmInstanceUuid = vmSpec.inventory.uuid
+            sessionId = currentEnvSpec.session.uuid
+        }
+
+        SimpleQuery<ImageCacheVO> q = dbf.createQuery(ImageCacheVO.class)
+        q.add(ImageCacheVO_.imageUuid, SimpleQuery.Op.EQ, imageSpec.inventory.uuid)
+        q.add(ImageCacheVO_.primaryStorageUuid, SimpleQuery.Op.EQ, primaryStorageSpec.inventory.uuid)
+        ImageCacheVO cache = q.find()
+
+        assert cache != null
+        assert cache.installUrl != null
+
+        psvo.state = PrimaryStorageState.Disabled
+        dbf.updateAndRefresh(psvo)
+        assert dbf.findByUuid(primaryStorageSpec.inventory.uuid, PrimaryStorageVO.class).state == PrimaryStorageState.Disabled
+
+        CephPrimaryStorageBase.CheckIsBitsExistingCmd cmd = null
+
+        env.afterSimulator(CephPrimaryStorageBase.CHECK_BITS_PATH) { rsp, HttpEntity<String> e ->
+            cmd = JSONObjectUtil.toObject(e.body, CephPrimaryStorageBase.CheckIsBitsExistingCmd.class)
+            return rsp
+        }
+        attachIsoToVmInstance {
+            isoUuid = imageSpec.inventory.uuid
+            vmInstanceUuid = vmSpec.inventory.uuid
+            sessionId = currentEnvSpec.session.uuid
+        }
+        assert cmd != null
+        assert cmd.installPath == cache.installUrl
+    }
+
+}

--- a/test/src/test/groovy/org/zstack/test/integration/storage/primary/ceph/AttachIsoCase2.groovy
+++ b/test/src/test/groovy/org/zstack/test/integration/storage/primary/ceph/AttachIsoCase2.groovy
@@ -1,0 +1,118 @@
+package org.zstack.test.integration.storage.primary.ceph
+
+import org.springframework.http.HttpEntity
+import org.zstack.core.db.DatabaseFacade
+import org.zstack.core.db.SimpleQuery
+import org.zstack.header.storage.backup.BackupStorageStatus
+import org.zstack.header.storage.primary.ImageCacheVO
+import org.zstack.header.storage.primary.ImageCacheVO_
+import org.zstack.kvm.KVMAgentCommands
+import org.zstack.kvm.KVMConstant
+import org.zstack.kvm.KVMHost
+import org.zstack.sdk.AttachIsoToVmInstanceAction
+import org.zstack.storage.backup.BackupStorageBase
+import org.zstack.storage.ceph.backup.CephBackupStorageBase
+import org.zstack.storage.ceph.backup.CephBackupStorageMonBase
+import org.zstack.storage.ceph.primary.CephPrimaryStorageBase
+import org.zstack.header.storage.primary.PrimaryStorageState
+import org.zstack.header.storage.primary.PrimaryStorageVO
+import org.zstack.header.storage.backup.BackupStorageVO
+import org.zstack.storage.ceph.primary.CephPrimaryStorageMonBase
+import org.zstack.testlib.BackupStorageSpec
+import org.zstack.testlib.ImageSpec
+import org.zstack.testlib.EnvSpec
+import org.zstack.testlib.PrimaryStorageSpec
+import org.zstack.testlib.CephPrimaryStorageSpec
+import org.zstack.testlib.SubCase
+import org.zstack.testlib.Test
+import org.zstack.testlib.VmSpec
+import org.zstack.test.integration.storage.CephEnv
+import org.zstack.test.integration.storage.StorageTest
+
+import org.zstack.utils.gson.JSONObjectUtil
+import sun.awt.image.ImageCache;
+/**
+ * Created by xing5 on 2017/2/27.
+ */
+class AttachIsoCase2 extends SubCase {
+    EnvSpec env
+
+    @Override
+    void setup() {
+        useSpring(StorageTest.springSpec)
+    }
+
+    @Override
+    void environment() {
+        env = CephEnv.CephStorageOneVmEnv()
+    }
+
+    @Override
+    void test() {
+        env.create {
+            testAttachIsoToDisabledCephStorageWhenIsoDeleted()
+        }
+    }
+
+    @Override
+    void clean(){
+        env.delete()
+    }
+
+
+
+    void testAttachIsoToDisabledCephStorageWhenIsoDeleted(){
+        PrimaryStorageSpec primaryStorageSpec = env.specByName("ceph-pri") as PrimaryStorageSpec
+        BackupStorageSpec backupStorageSpec = env.specByName("ceph-bk") as BackupStorageSpec
+        VmSpec vmSpec = env.specByName("test-vm") as VmSpec
+        ImageSpec imageSpec = env.specByName("test-iso") as ImageSpec
+        DatabaseFacade dbf = bean(DatabaseFacade.class)
+        assert primaryStorageSpec.inventory.uuid
+        assert vmSpec.inventory.uuid
+        assert imageSpec.inventory.uuid
+        assert backupStorageSpec.inventory.uuid
+
+
+        attachIsoToVmInstance {
+            isoUuid = imageSpec.inventory.uuid
+            vmInstanceUuid = vmSpec.inventory.uuid
+            sessionId =  currentEnvSpec.session.uuid
+        }
+        detachIsoFromVmInstance {
+            vmInstanceUuid = vmSpec.inventory.uuid
+            sessionId =  currentEnvSpec.session.uuid
+        }
+
+        SimpleQuery<ImageCacheVO> q = dbf.createQuery(ImageCacheVO.class)
+        q.add(ImageCacheVO_.imageUuid, SimpleQuery.Op.EQ, imageSpec.inventory.uuid)
+        q.add(ImageCacheVO_.primaryStorageUuid, SimpleQuery.Op.EQ, primaryStorageSpec.inventory.uuid)
+        ImageCacheVO cache = q.find()
+
+        assert cache != null
+        assert cache.installUrl != null
+
+        PrimaryStorageVO  psvo = dbf.findByUuid(primaryStorageSpec.inventory.uuid,PrimaryStorageVO.class)
+        psvo.state = PrimaryStorageState.Disabled
+        dbf.updateAndRefresh(psvo)
+        assert dbf.findByUuid(primaryStorageSpec.inventory.uuid,PrimaryStorageVO.class).state == PrimaryStorageState.Disabled
+
+
+        env.simulator(CephPrimaryStorageBase.CHECK_BITS_PATH) {
+            CephPrimaryStorageBase.CheckIsBitsExistingRsp rsp = new CephPrimaryStorageBase.CheckIsBitsExistingRsp()
+            rsp.success = false
+            return rsp
+        }
+
+        AttachIsoToVmInstanceAction a = new AttachIsoToVmInstanceAction()
+        a.isoUuid = imageSpec.inventory.uuid
+        a.vmInstanceUuid = vmSpec.inventory.uuid
+        a.sessionId = currentEnvSpec.session.uuid
+
+        assert dbf.findByUuid(backupStorageSpec.inventory.uuid,BackupStorageVO.class).status == BackupStorageStatus.Connected
+
+        AttachIsoToVmInstanceAction.Result res = a.call()
+        assert res.error != null : "fail to attach iso ${res.error}"
+
+    }
+
+}

--- a/testlib/src/main/java/org/zstack/testlib/CephBackupStorageSpec.groovy
+++ b/testlib/src/main/java/org/zstack/testlib/CephBackupStorageSpec.groovy
@@ -2,6 +2,7 @@ package org.zstack.testlib
 
 import org.springframework.http.HttpEntity
 import org.zstack.core.db.Q
+import org.zstack.header.agent.AgentResponse
 import org.zstack.storage.ceph.backup.CephBackupStorageBase
 import org.zstack.storage.ceph.backup.CephBackupStorageMonBase
 import org.zstack.storage.ceph.backup.CephBackupStorageMonVO
@@ -121,6 +122,16 @@ class CephBackupStorageSpec extends BackupStorageSpec {
             def rsp = new CephBackupStorageBase.GetImagesMetaDataRsp()
             rsp.imagesMetadata = "{\"uuid\":\"a603e80ea18f424f8a5f00371d484537\",\"name\":\"test\",\"description\":\"\",\"state\":\"Enabled\",\"status\":\"Ready\",\"size\":19862528,\"actualSize\":15794176,\"md5Sum\":\"not calculated\",\"url\":\"http://192.168.200.1/mirror/diskimages/zstack-image-1.2.qcow2\",\"mediaType\":\"RootVolumeTemplate\",\"type\":\"zstack\",\"platform\":\"Linux\",\"format\":\"qcow2\",\"system\":false,\"createDate\":\"Dec 22, 2016 5:10:06 PM\",\"lastOpDate\":\"Dec 22, 2016 5:10:08 PM\",\"backupStorageRefs\":[{\"id\":45,\"imageUuid\":\"a603e80ea18f424f8a5f00371d484537\",\"backupStorageUuid\":\"63879ceb90764f839d3de772aa646c83\",\"installPath\":\"/bs-sftp/rootVolumeTemplates/acct-36c27e8ff05c4780bf6d2fa65700f22e/a603e80ea18f424f8a5f00371d484537/zstack-image-1.2.template\",\"status\":\"Ready\",\"createDate\":\"Dec 22, 2016 5:10:08 PM\",\"lastOpDate\":\"Dec 22, 2016 5:10:08 PM\"}]}"
             return rsp
+        }
+        simulator(CephBackupStorageBase.PING_PATH) {
+            return new CephBackupStorageBase.PingRsp()
+        }
+
+        simulator(CephBackupStorageMonBase.PING_PATH) {
+            CephBackupStorageMonBase.PingRsp rsp = new CephBackupStorageMonBase.PingRsp()
+            rsp.success = true
+            return rsp
+
         }
     }
 }

--- a/testlib/src/main/java/org/zstack/testlib/CephPrimaryStorageSpec.groovy
+++ b/testlib/src/main/java/org/zstack/testlib/CephPrimaryStorageSpec.groovy
@@ -6,6 +6,8 @@ import org.zstack.core.db.Q
 import org.zstack.kvm.KVMAgentCommands
 import org.zstack.sdk.CephPrimaryStorageInventory
 import org.zstack.sdk.PrimaryStorageInventory
+import org.zstack.storage.ceph.backup.CephBackupStorageBase
+import org.zstack.storage.ceph.backup.CephBackupStorageMonBase
 import org.zstack.storage.ceph.primary.CephPrimaryStorageBase
 import org.zstack.storage.ceph.primary.CephPrimaryStorageMonBase
 import org.zstack.storage.ceph.primary.CephPrimaryStorageMonVO
@@ -168,8 +170,17 @@ class CephPrimaryStorageSpec extends PrimaryStorageSpec {
             return new CephPrimaryStorageBase.AgentResponse()
         }
 
+
         simulator(CephPrimaryStorageBase.ADD_POOL_PATH) {
             return new CephPrimaryStorageBase.AddPoolRsp()
+        }
+        simulator(CephPrimaryStorageBase.CHECK_BITS_PATH) {
+            return new CephPrimaryStorageBase.CheckIsBitsExistingRsp()
+        }
+        simulator(CephPrimaryStorageMonBase.PING_PATH) {
+            CephPrimaryStorageMonBase.PingRsp rsp = new CephPrimaryStorageMonBase.PingRsp()
+            rsp.success = true
+            return rsp
         }
     }
 


### PR DESCRIPTION
before: attach ISO to VM will succeed when PS is maintaining and disabled(ISO has been in PS) 
 and will fail when PS is disabled(ISO isn't in PS). NFS,Local,SMP will check the ISO whether be deleted but
Ceph didn't check the ISO whether be deleted.

except: attach ISO to VM will succeed when PS is disabled(ISO has been in PS) 
and will fail when PS is maintaining and disabled(ISO isn't in PS)
NFS,Local,SMP,Ceph check the ISO whether be deleted.


add 2 test case, if run the 2 test case in one case , it will fail caused by disconnected backup storage.

for

https://github.com/zstackio/issues/issues/1959