### PR TITLE
Fix bug 2337

### DIFF
--- a/plugin/fusionstor/src/main/java/org/zstack/storage/fusionstor/FusionstorMonBase.java
+++ b/plugin/fusionstor/src/main/java/org/zstack/storage/fusionstor/FusionstorMonBase.java
@@ -38,7 +38,7 @@ public abstract class FusionstorMonBase {
 
     protected void checkTools() {
         Ssh ssh = new Ssh();
-        ssh.setHostname(self.getHostname()).setUsername(self.getSshUsername()).setPassword(self.getSshPassword())
+        ssh.setHostname(self.getHostname()).setUsername(self.getSshUsername()).setPassword(self.getSshPassword()).setPort(self.getSshPort())
             .checkTool("/opt/fusionstack/lich/bin/lich", "/opt/fusionstack/lich/sbin/lichd").runErrorByExceptionAndClose();
     }
 


### PR DESCRIPTION
This patch fix "fusionstor changing ssh port doesn't take effect"
bug. When ssh, should point out which port will be used.