### PR TITLE
Fix an exception - in case VM has no imageUuid

### DIFF
--- a/compute/src/main/java/org/zstack/compute/vm/VmInstanceBase.java
+++ b/compute/src/main/java/org/zstack/compute/vm/VmInstanceBase.java
@@ -2164,8 +2164,12 @@ public class VmInstanceBase extends AbstractVmInstance {
     }
 
     private void checkImageMediaTypeCapabilities(Map<String, Object> ret) {
-        ImageVO vo = dbf.findByUuid(self.getImageUuid(), ImageVO.class);
+        ImageVO vo = null;
         ImageMediaType imageMediaType;
+
+        if (self.getImageUuid() != null) {
+            vo = dbf.findByUuid(self.getImageUuid(), ImageVO.class);
+        }
 
         if (vo == null) {
             imageMediaType = null;


### PR DESCRIPTION
e.g. The VM imported from vCenter doesn't have an imageUuid.

Signed-off-by: David Lee <live4thee@gmail.com>