### PR TITLE
for issue1264 

### DIFF
--- a/conf/db/upgrade/V1.10__schema.sql
+++ b/conf/db/upgrade/V1.10__schema.sql
@@ -36,4 +36,9 @@ FOR EACH ROW
     END $$
 DELIMITER ;
 
+ALTER TABLE `zstack`.`SharedResourceVO` DROP foreign key fkSharedResourceVOAccountVO;
+ALTER TABLE `zstack`.`SharedResourceVO` DROP INDEX `ownerAccountUuid`;
+ALTER TABLE `zstack`.`SharedResourceVO` ADD CONSTRAINT fkSharedResourceVOAccountVO FOREIGN KEY (ownerAccountUuid) REFERENCES AccountVO (uuid) ON DELETE CASCADE;
+ALTER TABLE `zstack`.`SharedResourceVO` ADD UNIQUE INDEX(`ownerAccountUuid`,`receiverAccountUuid`,`resourceUuid`,`toPublic`);
+
 


### PR DESCRIPTION
add unique index to ensure the same resouce only be shared to the same account one time.
 for https://github.com/zstackio/issues/issues/1264

./runMavenProfile deploydb success:
Migrating schema `zstack` to version 1.10 - schema
WARNING: DB: Trigger does not exist (SQL State: null - Error Code: 1360)
WARNING: DB: Trigger does not exist (SQL State: null - Error Code: 1360)
Successfully applied 16 migrations to schema `zstack` (execution time 00:55.914s).
Flyway 3.2.1 by Boxfuse
