### PR TITLE
Fix scheduler stopTime calculation error

### DIFF
--- a/core/src/main/java/org/zstack/core/scheduler/SchedulerFacadeImpl.java
+++ b/core/src/main/java/org/zstack/core/scheduler/SchedulerFacadeImpl.java
@@ -356,7 +356,11 @@ public class SchedulerFacadeImpl extends AbstractService implements SchedulerFac
                     if (schedulerJob.getRepeat() == 1) {
                         vo.setStopTime(start);
                     } else {
-                        vo.setStopTime(new Timestamp(schedulerJob.getStartTime().getTime() + schedulerJob.getRepeat() * schedulerJob.getSchedulerInterval() * 1000));
+                        if (start != null) {
+                            vo.setStopTime(new Timestamp( start.getTime() + schedulerJob.getRepeat() * schedulerJob.getSchedulerInterval() * 1000));
+                        } else {
+                            vo.setStopTime(new Timestamp( create.getTime() + schedulerJob.getRepeat() * schedulerJob.getSchedulerInterval() * 1000));
+                        }
                     }
                 } else {
                     vo.setStopTime(null);


### PR DESCRIPTION
for https://github.com/zstackio/issues/issues/1703
[Problem]
When calculate the time, ZStack use a new TimeStamp
but not the job create time.

[Solution]
Change to correct time.