### PR TITLE
Fix smp capacity don't release

### DIFF
--- a/compute/src/main/java/org/zstack/compute/host/HostBase.java
+++ b/compute/src/main/java/org/zstack/compute/host/HostBase.java
@@ -342,6 +342,7 @@ public abstract class HostBase extends AbstractHost {
 
         final String issuer = HostVO.class.getSimpleName();
         final List<HostInventory> ctx = Arrays.asList(HostInventory.valueOf(self));
+
         FlowChain chain = FlowChainBuilder.newSimpleFlowChain();
         chain.setName(String.format("delete-host-%s", msg.getUuid()));
         if (msg.getDeletionMode() == APIDeleteMessage.DeletionMode.Permissive) {

--- a/conf/springConfigXml/sharedMountPointPrimaryStorage.xml
+++ b/conf/springConfigXml/sharedMountPointPrimaryStorage.xml
@@ -15,6 +15,7 @@
         <zstack:plugin>
             <zstack:extension interface="org.zstack.header.storage.primary.PrimaryStorageFactory" />
             <zstack:extension interface="org.zstack.header.storage.snapshot.CreateTemplateFromVolumeSnapshotExtensionPoint" />
+            <zstack:extension interface="org.zstack.header.host.HostDeleteExtensionPoint"/>
         </zstack:plugin>
     </bean>
 

--- a/plugin/sharedMountPointPrimaryStorage/src/main/java/org/zstack/storage/primary/smp/SMPPrimaryStorageBase.java
+++ b/plugin/sharedMountPointPrimaryStorage/src/main/java/org/zstack/storage/primary/smp/SMPPrimaryStorageBase.java
@@ -272,7 +272,6 @@ public class SMPPrimaryStorageBase extends PrimaryStorageBase {
             completion.success();
             return;
         }
-
         new LoopAsyncBatch<String>(completion) {
             boolean success;
 

--- a/test/src/test/groovy/org/zstack/test/integration/storage/SMPEnv.groovy
+++ b/test/src/test/groovy/org/zstack/test/integration/storage/SMPEnv.groovy
@@ -1,0 +1,135 @@
+package org.zstack.test.integration.storage
+
+import org.zstack.header.network.service.NetworkServiceType
+import org.zstack.network.securitygroup.SecurityGroupConstant
+import org.zstack.network.service.virtualrouter.VirtualRouterConstant
+import org.zstack.testlib.EnvSpec
+import org.zstack.testlib.Test
+import org.zstack.utils.data.SizeUnit
+
+/**
+ * Created by zouye on 2017/3/1.
+ */
+class SMPEnv {
+    def DOC = """
+use:
+1. sftp backup storage
+2. SMP primary storage
+3. virtual router provider
+4. l2 novlan network
+5. security group
+"""
+
+    static EnvSpec oneVmBasicEnv() {
+        return Test.makeEnv {
+            instanceOffering {
+                name = "instanceOffering"
+                memory = SizeUnit.GIGABYTE.toByte(8)
+                cpu = 4
+            }
+
+            diskOffering {
+                name = "diskOffering"
+                diskSize = SizeUnit.GIGABYTE.toByte(20)
+            }
+
+            sftpBackupStorage {
+                name = "sftp"
+                url = "/sftp"
+                username = "root"
+                password = "password"
+                hostname = "localhost"
+
+                image {
+                    name = "image1"
+                    url  = "http://zstack.org/download/test.qcow2"
+                }
+
+                image {
+                    name = "vr"
+                    url  = "http://zstack.org/download/vr.qcow2"
+                }
+            }
+
+            zone {
+                name = "zone"
+                description = "test"
+
+                cluster {
+                    name = "cluster"
+                    hypervisorType = "KVM"
+
+                    kvm {
+                        name = "kvm"
+                        managementIp = "localhost"
+                        username = "root"
+                        password = "password"
+                    }
+
+                    attachPrimaryStorage("smp")
+                    attachL2Network("l2")
+                }
+
+                smpPrimaryStorage {
+                    name = "smp"
+                    url = "/test"
+                }
+
+                l2NoVlanNetwork {
+                    name = "l2"
+                    physicalInterface = "eth0"
+
+                    l3Network {
+                        name = "l3"
+
+                        service {
+                            provider = VirtualRouterConstant.PROVIDER_TYPE
+                            types = [NetworkServiceType.DHCP.toString(), NetworkServiceType.DNS.toString()]
+                        }
+
+                        service {
+                            provider = SecurityGroupConstant.SECURITY_GROUP_PROVIDER_TYPE
+                            types = [SecurityGroupConstant.SECURITY_GROUP_NETWORK_SERVICE_TYPE]
+                        }
+
+                        ip {
+                            startIp = "192.168.100.10"
+                            endIp = "192.168.100.100"
+                            netmask = "255.255.255.0"
+                            gateway = "192.168.100.1"
+                        }
+                    }
+
+                    l3Network {
+                        name = "pubL3"
+
+                        ip {
+                            startIp = "12.16.10.10"
+                            endIp = "12.16.10.100"
+                            netmask = "255.255.255.0"
+                            gateway = "12.16.10.1"
+                        }
+                    }
+                }
+
+                virtualRouterOffering {
+                    name = "vr"
+                    memory = SizeUnit.MEGABYTE.toByte(512)
+                    cpu = 2
+                    useManagementL3Network("pubL3")
+                    usePublicL3Network("pubL3")
+                    useImage("vr")
+                }
+
+                attachBackupStorage("sftp")
+            }
+
+            vm {
+                name = "vm"
+                useInstanceOffering("instanceOffering")
+                useImage("image1")
+                useL3Networks("l3")
+            }
+        }
+    }
+}

--- a/test/src/test/groovy/org/zstack/test/integration/storage/StorageTest.groovy
+++ b/test/src/test/groovy/org/zstack/test/integration/storage/StorageTest.groovy
@@ -1,6 +1,7 @@
 package org.zstack.test.integration.storage
 
 import org.zstack.test.integration.storage.primary.local.LocalStorageMigrateVolumeCase
+import org.zstack.test.integration.storage.primary.smp.SMPCapacityCase
 import org.zstack.testlib.SpringSpec
 import org.zstack.testlib.Test
 
@@ -32,7 +33,8 @@ class StorageTest extends Test {
     @Override
     void test() {
         runSubCases([
-                new LocalStorageMigrateVolumeCase()
+                new LocalStorageMigrateVolumeCase(),
+                new SMPCapacityCase()
         ])
     }
 }

--- a/test/src/test/groovy/org/zstack/test/integration/storage/primary/smp/SMPCapacityCase.groovy
+++ b/test/src/test/groovy/org/zstack/test/integration/storage/primary/smp/SMPCapacityCase.groovy
@@ -1,0 +1,60 @@
+package org.zstack.test.integration.storage.primary.smp
+
+import org.zstack.header.storage.primary.PrimaryStorageCapacityVO
+import org.zstack.sdk.PrimaryStorageInventory
+import org.zstack.test.integration.storage.SMPEnv
+import org.zstack.testlib.EnvSpec
+import org.zstack.testlib.HostSpec
+import org.zstack.testlib.SubCase
+
+/**
+ * Created by zouye on 2017/3/1.
+ */
+class SMPCapacityCase extends SubCase{
+    EnvSpec env
+
+    @Override
+    void setup() {
+        spring {
+            sftpBackupStorage()
+            smp()
+            virtualRouter()
+            vyos()
+            kvm()
+        }
+    }
+
+    @Override
+    void environment() {
+        env = SMPEnv.oneVmBasicEnv()
+    }
+
+    @Override
+    void test() {
+        env.create {
+            testReleaseSMPCapacityWithNoHostInCase()
+        }
+    }
+
+    private void testReleaseSMPCapacityWithNoHostInCase() {
+        HostSpec hostSpec =  env.specByName("kvm")
+        PrimaryStorageInventory inv = env.specByName("smp")
+
+        deleteHost {
+            uuid = hostSpec.inventory.uuid
+        }
+
+        PrimaryStorageCapacityVO vo = dbFindByUuid(inv.uuid, PrimaryStorageCapacityVO.class)
+
+        assert vo.getAvailablePhysicalCapacity() == 0L
+        assert vo.getAvailableCapacity() == 0L
+        assert vo.getTotalPhysicalCapacity() == 0L
+        assert vo.getTotalCapacity() == 0L
+        assert vo.getSystemUsedCapacity() == 0L
+    }
+
+    @Override
+    void clean() {
+        env.delete()
+    }
+}

--- a/test/src/test/resources/springConfigXml/DeletHostExtension.xml
+++ b/test/src/test/resources/springConfigXml/DeletHostExtension.xml
@@ -4,11 +4,7 @@
        xmlns:zstack="http://zstack.org/schema/zstack"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
          http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-
-
-
-
-     	 http://zstack.org/schema/zstack 
+     	 http://zstack.org/schema/zstack
          http://zstack.org/schema/zstack/plugin.xsd"
        default-init-method="init" default-destroy-method="destory">
 	

--- a/test/src/test/resources/springConfigXml/smpPrimaryStorageSimulator.xml
+++ b/test/src/test/resources/springConfigXml/smpPrimaryStorageSimulator.xml
@@ -1,11 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
-       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans
+	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans
          http://www.springframework.org/schema/beans/spring-beans-3.0.xsd"
-       default-init-method="init" default-destroy-method="destory">
+	   default-init-method="init" default-destroy-method="destory">
 
 
 	<bean id="SMPPrimaryStorageSimulatorConfig" class="org.zstack.storage.primary.smp.SMPPrimaryStorageSimulatorConfig" />
-
 </beans>


### PR DESCRIPTION
for https://github.com/zstackio/issues/issues/1645

[Problem]
 when use NFS offer share mount point as primary storage, delete 
all the hosts inside the smp cluster,  the primary storage capacity 
doesn't release

[Solution]
Implement HostDeleteExtensionPoint in SMPPrimaryStorageFactory
and use primaryStorageCapacityUpdater to set the capacity to zero
when use Share Mount Point as Primary Storage and the cluster has 
no host inside.