### PR TITLE
allow to attac ISO to VM when PS is disabled

### DIFF
--- a/plugin/ceph/src/main/java/org/zstack/storage/ceph/primary/CephPrimaryStorageBase.java
+++ b/plugin/ceph/src/main/java/org/zstack/storage/ceph/primary/CephPrimaryStorageBase.java
@@ -4,6 +4,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.zstack.core.Platform;
 import org.zstack.core.cloudbus.CloudBusCallBack;
 import org.zstack.core.cloudbus.CloudBusListCallBack;
+import org.zstack.core.db.Q;
 import org.zstack.core.db.SimpleQuery;
 import org.zstack.core.db.SimpleQuery.Op;
 import org.zstack.core.thread.AsyncThread;
@@ -571,6 +572,18 @@ public class CephPrimaryStorageBase extends PrimaryStorageBase {
     public static class RollbackSnapshotRsp extends AgentResponse {
     }
 
+    public static class CheckIsBitsExistingCmd extends AgentCommand {
+        String installPath;
+
+        public void setInstallPath(String installPath) {
+            this.installPath = installPath;
+        }
+
+        public String getInstallPath() {
+            return installPath;
+        }
+    }
+
     public static class CreateKvmSecretCmd extends KVMAgentCommands.AgentCommand {
         String userKey;
         String uuid;
@@ -657,6 +670,7 @@ public class CephPrimaryStorageBase extends PrimaryStorageBase {
     public static final String GET_FACTS = "/ceph/primarystorage/facts";
     public static final String DELETE_IMAGE_CACHE = "/ceph/primarystorage/deleteimagecache";
     public static final String ADD_POOL_PATH = "/ceph/primarystorage/addpool";
+    public static final String CHECK_BITS_PATH = "/ceph/primarystorage/snapshot/checkbits";
 
     private final Map<String, BackupStorageMediator> backupStorageMediators = new HashMap<String, BackupStorageMediator>();
 
@@ -1137,17 +1151,15 @@ public class CephPrimaryStorageBase extends PrimaryStorageBase {
 
     class DownloadToCache {
         ImageSpec image;
-
         private void doDownload(final ReturnValueCompletion<ImageCacheVO> completion) {
-            SimpleQuery<ImageCacheVO> q = dbf.createQuery(ImageCacheVO.class);
-            q.add(ImageCacheVO_.imageUuid, Op.EQ, image.getInventory().getUuid());
-            q.add(ImageCacheVO_.primaryStorageUuid, Op.EQ, self.getUuid());
-            ImageCacheVO cache = q.find();
+            ImageCacheVO cache = Q.New(ImageCacheVO.class)
+                    .eq(ImageCacheVO_.primaryStorageUuid, self.getUuid())
+                    .eq(ImageCacheVO_.imageUuid, image.getInventory().getUuid())
+                    .find();
             if (cache != null) {
                 completion.success(cache);
                 return;
             }
-
             final FlowChain chain = FlowChainBuilder.newShareFlowChain();
             chain.setName(String.format("prepare-image-cache-ceph-%s", self.getUuid()));
             chain.then(new ShareFlow() {
@@ -1354,19 +1366,68 @@ public class CephPrimaryStorageBase extends PrimaryStorageBase {
 
                 @Override
                 public void run(final SyncTaskChain chain) {
-                    doDownload(new ReturnValueCompletion<ImageCacheVO>(chain) {
-                        @Override
-                        public void success(ImageCacheVO returnValue) {
-                            completion.success(returnValue);
-                            chain.next();
-                        }
+                    ImageCacheVO cache = Q.New(ImageCacheVO.class)
+                            .eq(ImageCacheVO_.primaryStorageUuid, self.getUuid())
+                            .eq(ImageCacheVO_.imageUuid, image.getInventory().getUuid())
+                            .find();
 
-                        @Override
-                        public void fail(ErrorCode errorCode) {
-                            completion.fail(errorCode);
-                            chain.next();
-                        }
-                    });
+                    if (cache != null ){
+                        final CheckIsBitsExistingCmd cmd = new CheckIsBitsExistingCmd();
+                        cmd.setInstallPath(cache.getInstallUrl());
+                        httpCall(CHECK_BITS_PATH, cmd, CheckIsBitsExistingRsp.class, new ReturnValueCompletion<CheckIsBitsExistingRsp>(chain) {
+                            @Override
+                            public void success(CheckIsBitsExistingRsp returnValue) {
+                                logger.debug("ISO has been existing");
+                                completion.success(cache);
+                            }
+
+                            @Override
+                            public void fail(ErrorCode errorCode) {
+                                logger.debug("image not found, remove vo and re-download");
+                                SimpleQuery<ImageCacheVO> q = dbf.createQuery(ImageCacheVO.class);
+                                q.add(ImageCacheVO_.primaryStorageUuid, Op.EQ, self.getUuid());
+                                q.add(ImageCacheVO_.imageUuid, Op.EQ, image.getInventory().getUuid());
+                                ImageCacheVO cvo = q.find();
+
+                                ReturnPrimaryStorageCapacityMsg rmsg = new ReturnPrimaryStorageCapacityMsg();
+                                rmsg.setDiskSize(cvo.getSize());
+                                rmsg.setPrimaryStorageUuid(cvo.getPrimaryStorageUuid());
+                                bus.makeTargetServiceIdByResourceUuid(rmsg, PrimaryStorageConstant.SERVICE_ID, cvo.getPrimaryStorageUuid());
+                                bus.send(rmsg);
+                                dbf.remove(cvo);
+
+                                doDownload(new ReturnValueCompletion<ImageCacheVO>(chain) {
+                                    @Override
+                                    public void success(ImageCacheVO returnValue) {
+                                        completion.success(returnValue);
+                                        chain.next();
+                                    }
+
+                                    @Override
+                                    public void fail(ErrorCode errorCode) {
+                                        completion.fail(errorCode);
+                                        chain.next();
+                                    }
+                                });
+                            }
+                        });
+
+                    }else{
+                        doDownload(new ReturnValueCompletion<ImageCacheVO>(chain) {
+                            @Override
+                            public void success(ImageCacheVO returnValue) {
+                                completion.success(returnValue);
+                                chain.next();
+                            }
+
+                            @Override
+                            public void fail(ErrorCode errorCode) {
+                                completion.fail(errorCode);
+                                chain.next();
+                            }
+                        });
+                    }
+
                 }
 
                 @Override
@@ -1575,6 +1636,7 @@ public class CephPrimaryStorageBase extends PrimaryStorageBase {
 
             @Override
             public void fail(ErrorCode errorCode) {
+
                 reply.setError(errorCode);
                 bus.reply(msg, reply);
             }
@@ -2396,6 +2458,9 @@ public class CephPrimaryStorageBase extends PrimaryStorageBase {
         public String vmUuid;
         public String account;
         public String password;
+    }
+    public static class CheckIsBitsExistingRsp extends AgentResponse {
+
     }
 
     private void handle(DeleteImageCacheOnPrimaryStorageMsg msg) {

--- a/test/src/test/groovy/org/zstack/test/integration/storage/CephEnv.groovy
+++ b/test/src/test/groovy/org/zstack/test/integration/storage/CephEnv.groovy
@@ -1,0 +1,124 @@
+package org.zstack.test.integration.storage
+
+import org.bouncycastle.jce.provider.symmetric.TEA
+import org.zstack.header.network.service.NetworkServiceType
+import org.zstack.network.service.eip.EipConstant
+import org.zstack.network.service.flat.FlatNetworkServiceConstant
+import org.zstack.network.service.userdata.UserdataConstant
+import org.zstack.test.network.TestAcquireIp
+import org.zstack.testlib.EnvSpec
+import org.zstack.testlib.Test
+import org.zstack.utils.data.SizeUnit
+
+/**
+ * Created by Administrator on 2017-03-01.
+ */
+class CephEnv {
+    def DOC = """
+use:
+1. Ceph primary storage
+"""
+
+
+    static EnvSpec CephStorageOneVmEnv(){
+        return Test.makeEnv {
+            instanceOffering {
+                name = "instanceOffering"
+                memory = SizeUnit.GIGABYTE.toByte(8)
+                cpu = 4
+                }
+            diskOffering {
+                name = "diskOffering"
+                diskSize = SizeUnit.GIGABYTE.toByte(20)
+                }
+            zone{
+                name = "zone"
+                cluster {
+                    name = "test-cluster"
+                    hypervisorType = "KVM"
+
+                    kvm {
+                        name = "ceph-mon"
+                        managementIp = "localhost"
+                        username = "root"
+                        password = "password"
+                        usedMem = 1000
+                        totalCpu = 10
+                    }
+                    kvm {
+                        name = "host"
+                        username = "root"
+                        password = "password"
+                        usedMem = 1000
+                        totalCpu = 10
+                    }
+
+                    attachPrimaryStorage("ceph-pri")
+                    attachL2Network("l2")
+                }
+                l2NoVlanNetwork {
+                    name = "l2"
+                    physicalInterface = "eth0"
+
+                    l3Network {
+                        name = "l3"
+
+
+
+                        ip {
+                            startIp = "192.168.100.10"
+                            endIp = "192.168.100.100"
+                            netmask = "255.255.255.0"
+                            gateway = "192.168.100.1"
+                        }
+                    }
+                }
+
+                cephPrimaryStorage {
+                    name="ceph-pri"
+                    description="Test"
+                    totalCapacity = SizeUnit.GIGABYTE.toByte(100)
+                    availableCapacity= SizeUnit.GIGABYTE.toByte(100)
+                    url="ceph://pri"
+                    fsid="7ff218d9-f525-435f-8a40-3618d1772a64"
+                    monUrls=["root:password@localhost/?monPort=7777"]
+
+                }
+                
+
+                attachBackupStorage("ceph-bk")
+            }
+
+            cephBackupStorage {
+                name="ceph-bk"
+                description="Test"
+                totalCapacity = SizeUnit.GIGABYTE.toByte(100)
+                availableCapacity= SizeUnit.GIGABYTE.toByte(100)
+                url = "/bk"
+                fsid ="7ff218d9-f525-435f-8a40-3618d1772a64"
+                monUrls = ["root:password@localhost/?monPort=7777"]
+
+                image {
+                    name = "test-iso"
+                    url  = "http://zstack.org/download/test.iso"
+                }
+                image {
+                    name = "image"
+                    url  = "http://zstack.org/download/image.qcow2"
+                }
+            }
+
+            vm {
+                name = "test-vm"
+                useCluster("test-cluster")
+                useHost("host")
+                useL3Networks("l3")
+                useInstanceOffering("instanceOffering")
+                useRootDiskOffering("diskOffering")
+                useImage("image")
+
+            }
+
+        }
+    }
+}

--- a/test/src/test/groovy/org/zstack/test/integration/storage/StorageTest.groovy
+++ b/test/src/test/groovy/org/zstack/test/integration/storage/StorageTest.groovy
@@ -1,5 +1,7 @@
 package org.zstack.test.integration.storage
 
+import org.zstack.test.integration.storage.primary.ceph.AttachIsoCase
+import org.zstack.test.integration.storage.primary.ceph.AttachIsoCase2
 import org.zstack.test.integration.storage.primary.local.LocalStorageMigrateVolumeCase
 import org.zstack.test.integration.storage.primary.nfs.NfsGCCase
 import org.zstack.test.integration.storage.primary.smp.SMPCapacityCase
@@ -36,7 +38,8 @@ class StorageTest extends Test {
         runSubCases([
                 new LocalStorageMigrateVolumeCase(),
                 new SMPCapacityCase(),
-                new NfsGCCase()
+                new NfsGCCase(),
+                new AttachIsoCase()
         ])
     }
 }

--- a/test/src/test/groovy/org/zstack/test/integration/storage/primary/ceph/AttachIsoCase.groovy
+++ b/test/src/test/groovy/org/zstack/test/integration/storage/primary/ceph/AttachIsoCase.groovy
@@ -1,0 +1,139 @@
+package org.zstack.test.integration.storage.primary.ceph
+
+import org.springframework.http.HttpEntity
+import org.zstack.core.db.DatabaseFacade
+import org.zstack.core.db.Q
+import org.zstack.core.db.SimpleQuery
+import org.zstack.header.storage.backup.BackupStorageStatus
+import org.zstack.header.storage.primary.ImageCacheVO
+import org.zstack.header.storage.primary.ImageCacheVO_
+import org.zstack.header.storage.primary.PrimaryStorageVO_
+import org.zstack.kvm.KVMAgentCommands
+import org.zstack.kvm.KVMConstant
+import org.zstack.kvm.KVMHost
+import org.zstack.sdk.AttachIsoToVmInstanceAction
+import org.zstack.storage.backup.BackupStorageBase
+import org.zstack.storage.ceph.backup.CephBackupStorageBase
+import org.zstack.storage.ceph.backup.CephBackupStorageMonBase
+import org.zstack.storage.ceph.primary.CephPrimaryStorageBase
+import org.zstack.header.storage.primary.PrimaryStorageState
+import org.zstack.header.storage.primary.PrimaryStorageVO
+import org.zstack.header.storage.backup.BackupStorageVO
+import org.zstack.storage.ceph.primary.CephPrimaryStorageMonBase
+import org.zstack.testlib.BackupStorageSpec
+import org.zstack.testlib.ImageSpec
+import org.zstack.testlib.EnvSpec
+import org.zstack.testlib.PrimaryStorageSpec
+import org.zstack.testlib.CephPrimaryStorageSpec
+import org.zstack.testlib.SubCase
+import org.zstack.testlib.Test
+import org.zstack.testlib.VmSpec
+import org.zstack.test.integration.storage.CephEnv
+import org.zstack.test.integration.storage.StorageTest
+
+import org.zstack.utils.gson.JSONObjectUtil
+import sun.awt.image.ImageCache;
+/**
+ * Created by xing5 on 2017/2/27.
+ */
+class AttachIsoCase extends SubCase {
+    EnvSpec env
+
+    @Override
+    void setup() {
+        useSpring(StorageTest.springSpec)
+    }
+
+    @Override
+    void environment() {
+        env = CephEnv.CephStorageOneVmEnv()
+    }
+
+    @Override
+    void test() {
+        env.create {
+            testAttachIsoToMaintenanceCephStorageWhenIsoNotExisting()
+            testAttachIsoToMaintenanceCephStorageWhenIsoExisting()
+        }
+    }
+
+    @Override
+    void clean() {
+        env.delete()
+    }
+
+    void testAttachIsoToMaintenanceCephStorageWhenIsoNotExisting() {
+        String vmUuid = (env.specByName("test-vm") as VmSpec).inventory.uuid
+        String imageUuid = (env.specByName("test-iso") as ImageSpec).inventory.uuid
+        String psUuid = (env.specByName("ceph-pri") as PrimaryStorageSpec).inventory.uuid
+        DatabaseFacade dbf = bean(DatabaseFacade.class)
+
+        assert psUuid
+        assert vmUuid
+        assert imageUuid
+
+        PrimaryStorageVO psvo = dbf.findByUuid(psUuid, PrimaryStorageVO.class)
+        psvo.state = PrimaryStorageState.Disabled
+        dbf.updateAndRefresh(psvo)
+        assert dbf.findByUuid(psUuid, PrimaryStorageVO.class).state == PrimaryStorageState.Disabled
+
+        AttachIsoToVmInstanceAction a = new AttachIsoToVmInstanceAction()
+        a.isoUuid = imageUuid
+        a.vmInstanceUuid = vmUuid
+        a.sessionId = currentEnvSpec.session.uuid
+
+        AttachIsoToVmInstanceAction.Result res = a.call()
+        assert res.error != null : "fail to attach iso ${res.error}"
+
+    }
+
+    void testAttachIsoToMaintenanceCephStorageWhenIsoExisting() {
+        String vmUuid = (env.specByName("test-vm") as VmSpec).inventory.uuid
+        String imageUuid = (env.specByName("test-iso") as ImageSpec).inventory.uuid
+        String psUuid = (env.specByName("ceph-pri") as PrimaryStorageSpec).inventory.uuid
+        DatabaseFacade dbf = bean(DatabaseFacade.class)
+
+        assert psUuid
+        assert vmUuid
+        assert imageUuid
+
+
+        attachIsoToVmInstance {
+            isoUuid = imageUuid
+            vmInstanceUuid = vmUuid
+            sessionId = currentEnvSpec.session.uuid
+        }
+        detachIsoFromVmInstance {
+            vmInstanceUuid = vmUuid
+            sessionId = currentEnvSpec.session.uuid
+        }
+
+        ImageCacheVO cache = Q.New(ImageCacheVO.class)
+                .eq(ImageCacheVO_.primaryStorageUuid, psUuid)
+                .eq(ImageCacheVO_.imageUuid, imageUuid)
+                .find()
+
+
+        assert cache != null
+        assert cache.installUrl != null
+
+        PrimaryStorageVO psvo = dbf.findByUuid(psUuid, PrimaryStorageVO.class)
+        psvo.state = PrimaryStorageState.Disabled
+        dbf.updateAndRefresh(psvo)
+        assert dbf.findByUuid(psUuid, PrimaryStorageVO.class).state == PrimaryStorageState.Disabled
+
+        CephPrimaryStorageBase.CheckIsBitsExistingCmd cmd = null
+
+        env.afterSimulator(CephPrimaryStorageBase.CHECK_BITS_PATH) { rsp, HttpEntity<String> e ->
+            cmd = JSONObjectUtil.toObject(e.body, CephPrimaryStorageBase.CheckIsBitsExistingCmd.class)
+            return rsp
+        }
+        attachIsoToVmInstance {
+            isoUuid = imageUuid
+            vmInstanceUuid = vmUuid
+            sessionId = currentEnvSpec.session.uuid
+        }
+        assert cmd != null
+        assert cmd.installPath == cache.installUrl
+    }
+}

--- a/test/src/test/groovy/org/zstack/test/integration/storage/primary/ceph/AttachIsoCase2.groovy
+++ b/test/src/test/groovy/org/zstack/test/integration/storage/primary/ceph/AttachIsoCase2.groovy
@@ -1,0 +1,117 @@
+package org.zstack.test.integration.storage.primary.ceph
+
+import org.springframework.http.HttpEntity
+import org.zstack.core.db.DatabaseFacade
+import org.zstack.core.db.Q
+import org.zstack.core.db.SimpleQuery
+import org.zstack.header.storage.backup.BackupStorageStatus
+import org.zstack.header.storage.primary.ImageCacheVO
+import org.zstack.header.storage.primary.ImageCacheVO_
+import org.zstack.kvm.KVMAgentCommands
+import org.zstack.kvm.KVMConstant
+import org.zstack.kvm.KVMHost
+import org.zstack.sdk.AttachIsoToVmInstanceAction
+import org.zstack.storage.backup.BackupStorageBase
+import org.zstack.storage.ceph.backup.CephBackupStorageBase
+import org.zstack.storage.ceph.backup.CephBackupStorageMonBase
+import org.zstack.storage.ceph.primary.CephPrimaryStorageBase
+import org.zstack.header.storage.primary.PrimaryStorageState
+import org.zstack.header.storage.primary.PrimaryStorageVO
+import org.zstack.header.storage.backup.BackupStorageVO
+import org.zstack.storage.ceph.primary.CephPrimaryStorageMonBase
+import org.zstack.testlib.BackupStorageSpec
+import org.zstack.testlib.ImageSpec
+import org.zstack.testlib.EnvSpec
+import org.zstack.testlib.PrimaryStorageSpec
+import org.zstack.testlib.CephPrimaryStorageSpec
+import org.zstack.testlib.SubCase
+import org.zstack.testlib.Test
+import org.zstack.testlib.VmSpec
+import org.zstack.test.integration.storage.CephEnv
+import org.zstack.test.integration.storage.StorageTest
+
+import org.zstack.utils.gson.JSONObjectUtil
+import sun.awt.image.ImageCache;
+/**
+ * Created by xing5 on 2017/2/27.
+ */
+class AttachIsoCase2 extends SubCase {
+    EnvSpec env
+
+    @Override
+    void setup() {
+        useSpring(StorageTest.springSpec)
+    }
+
+    @Override
+    void environment() {
+        env = CephEnv.CephStorageOneVmEnv()
+    }
+
+    @Override
+    void test() {
+        env.create {
+            testAttachIsoToMaintenanceCephStorageWhenIsoDeleted()
+        }
+    }
+
+    @Override
+    void clean(){
+        env.delete()
+    }
+
+
+
+    void testAttachIsoToMaintenanceCephStorageWhenIsoDeleted(){
+        String vmUuid = (env.specByName("test-vm") as VmSpec).inventory.uuid
+        String imageUuid = (env.specByName("test-iso") as ImageSpec).inventory.uuid
+        String psUuid = (env.specByName("ceph-pri") as PrimaryStorageSpec).inventory.uuid
+        BackupStorageSpec backupStorageSpec = env.specByName("ceph-bk") as BackupStorageSpec
+        DatabaseFacade dbf = bean(DatabaseFacade.class)
+
+        assert vmUuid
+        assert imageUuid
+        assert psUuid
+        assert backupStorageSpec.inventory.uuid
+
+        attachIsoToVmInstance {
+            isoUuid = imageUuid
+            vmInstanceUuid = vmUuid
+            sessionId =  currentEnvSpec.session.uuid
+        }
+        detachIsoFromVmInstance {
+            vmInstanceUuid = vmUuid
+            sessionId =  currentEnvSpec.session.uuid
+        }
+
+        ImageCacheVO cache = Q.New(ImageCacheVO.class)
+                .eq(ImageCacheVO_.primaryStorageUuid, psUuid)
+                .eq(ImageCacheVO_.imageUuid, imageUuid)
+                .find()
+
+        assert cache != null
+        assert cache.installUrl != null
+
+        PrimaryStorageVO  psvo = dbf.findByUuid(psUuid, PrimaryStorageVO.class)
+        psvo.state = PrimaryStorageState.Disabled
+        dbf.updateAndRefresh(psvo)
+        assert dbf.findByUuid(psUuid, PrimaryStorageVO.class).state == PrimaryStorageState.Disabled
+
+
+        env.simulator(CephPrimaryStorageBase.CHECK_BITS_PATH) {
+            CephPrimaryStorageBase.CheckIsBitsExistingRsp rsp = new CephPrimaryStorageBase.CheckIsBitsExistingRsp()
+            rsp.success = false
+            return rsp
+        }
+
+        AttachIsoToVmInstanceAction a = new AttachIsoToVmInstanceAction()
+        a.isoUuid = imageUuid
+        a.vmInstanceUuid = vmUuid
+        a.sessionId = currentEnvSpec.session.uuid
+
+        AttachIsoToVmInstanceAction.Result res = a.call()
+        assert res.error != null : "fail to attach iso ${res.error}"
+
+    }
+
+}

--- a/testlib/src/main/java/org/zstack/testlib/CephBackupStorageSpec.groovy
+++ b/testlib/src/main/java/org/zstack/testlib/CephBackupStorageSpec.groovy
@@ -2,6 +2,7 @@ package org.zstack.testlib
 
 import org.springframework.http.HttpEntity
 import org.zstack.core.db.Q
+import org.zstack.header.agent.AgentResponse
 import org.zstack.storage.ceph.backup.CephBackupStorageBase
 import org.zstack.storage.ceph.backup.CephBackupStorageMonBase
 import org.zstack.storage.ceph.backup.CephBackupStorageMonVO
@@ -121,6 +122,16 @@ class CephBackupStorageSpec extends BackupStorageSpec {
             def rsp = new CephBackupStorageBase.GetImagesMetaDataRsp()
             rsp.imagesMetadata = "{\"uuid\":\"a603e80ea18f424f8a5f00371d484537\",\"name\":\"test\",\"description\":\"\",\"state\":\"Enabled\",\"status\":\"Ready\",\"size\":19862528,\"actualSize\":15794176,\"md5Sum\":\"not calculated\",\"url\":\"http://192.168.200.1/mirror/diskimages/zstack-image-1.2.qcow2\",\"mediaType\":\"RootVolumeTemplate\",\"type\":\"zstack\",\"platform\":\"Linux\",\"format\":\"qcow2\",\"system\":false,\"createDate\":\"Dec 22, 2016 5:10:06 PM\",\"lastOpDate\":\"Dec 22, 2016 5:10:08 PM\",\"backupStorageRefs\":[{\"id\":45,\"imageUuid\":\"a603e80ea18f424f8a5f00371d484537\",\"backupStorageUuid\":\"63879ceb90764f839d3de772aa646c83\",\"installPath\":\"/bs-sftp/rootVolumeTemplates/acct-36c27e8ff05c4780bf6d2fa65700f22e/a603e80ea18f424f8a5f00371d484537/zstack-image-1.2.template\",\"status\":\"Ready\",\"createDate\":\"Dec 22, 2016 5:10:08 PM\",\"lastOpDate\":\"Dec 22, 2016 5:10:08 PM\"}]}"
             return rsp
+        }
+        simulator(CephBackupStorageBase.PING_PATH) {
+            return new CephBackupStorageBase.PingRsp()
+        }
+
+        simulator(CephBackupStorageMonBase.PING_PATH) {
+            CephBackupStorageMonBase.PingRsp rsp = new CephBackupStorageMonBase.PingRsp()
+            rsp.success = true
+            return rsp
+
         }
     }
 }

--- a/testlib/src/main/java/org/zstack/testlib/CephPrimaryStorageSpec.groovy
+++ b/testlib/src/main/java/org/zstack/testlib/CephPrimaryStorageSpec.groovy
@@ -6,6 +6,8 @@ import org.zstack.core.db.Q
 import org.zstack.kvm.KVMAgentCommands
 import org.zstack.sdk.CephPrimaryStorageInventory
 import org.zstack.sdk.PrimaryStorageInventory
+import org.zstack.storage.ceph.backup.CephBackupStorageBase
+import org.zstack.storage.ceph.backup.CephBackupStorageMonBase
 import org.zstack.storage.ceph.primary.CephPrimaryStorageBase
 import org.zstack.storage.ceph.primary.CephPrimaryStorageMonBase
 import org.zstack.storage.ceph.primary.CephPrimaryStorageMonVO
@@ -168,8 +170,17 @@ class CephPrimaryStorageSpec extends PrimaryStorageSpec {
             return new CephPrimaryStorageBase.AgentResponse()
         }
 
+
         simulator(CephPrimaryStorageBase.ADD_POOL_PATH) {
             return new CephPrimaryStorageBase.AddPoolRsp()
+        }
+        simulator(CephPrimaryStorageBase.CHECK_BITS_PATH) {
+            return new CephPrimaryStorageBase.CheckIsBitsExistingRsp()
+        }
+        simulator(CephPrimaryStorageMonBase.PING_PATH) {
+            CephPrimaryStorageMonBase.PingRsp rsp = new CephPrimaryStorageMonBase.PingRsp()
+            rsp.success = true
+            return rsp
         }
     }
 


### PR DESCRIPTION
before: attach ISO to VM will succeed when PS is maintaining and disabled(ISO has been in PS)
and will fail when PS is disabled(ISO isn't in PS). NFS,Local,SMP will check the ISO whether be deleted but
Ceph didn't check the ISO whether be deleted.

except: attach ISO to VM will succeed when PS is disabled(ISO has been in PS)
and will fail when PS is maintaining and disabled(ISO isn't in PS)
NFS,Local,SMP,Ceph check the ISO whether be deleted.
 for https://github.com/zstackio/issues/issues/1959