### PR TITLE
Enhance the leastVmPreferredHostAllocator

### DIFF
--- a/compute/src/main/java/org/zstack/compute/allocator/LeastVmPreferredAllocatorFlow.java
+++ b/compute/src/main/java/org/zstack/compute/allocator/LeastVmPreferredAllocatorFlow.java
@@ -7,19 +7,15 @@ import org.springframework.transaction.annotation.Transactional;
 import org.zstack.core.db.DatabaseFacade;
 import org.zstack.header.allocator.AbstractHostAllocatorFlow;
 import org.zstack.header.host.HostVO;
-import org.zstack.utils.CollectionDSL;
-import org.zstack.utils.CollectionUtils;
 import org.zstack.utils.Utils;
-import org.zstack.utils.function.Function;
 import org.zstack.utils.logging.CLogger;
 
 import javax.persistence.Tuple;
 import javax.persistence.TypedQuery;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 /**
+ * This flow returns a list of host candidates sorted by the number of their VMs.
  */
 @Configurable(preConstruction = true, autowire = Autowire.BY_TYPE)
 public class LeastVmPreferredAllocatorFlow extends AbstractHostAllocatorFlow {
@@ -27,21 +23,15 @@ public class LeastVmPreferredAllocatorFlow extends AbstractHostAllocatorFlow {
     @Autowired
     private DatabaseFacade dbf;
 
-    class VmNumHost {
-        long vmNum;
-        String hostUuid;
-    }
-
     @Transactional(readOnly = true)
     private List<Tuple> findLeastVmHost(List<String> huuids) {
-        String sql = "select count(vm), host.uuid" +
+        String sql = "select count(vm) as cnt, host.uuid" +
                 " from VmInstanceVO vm, HostVO host" +
                 " where vm.hostUuid = host.uuid" +
                 " and host.uuid in (:huuids)" +
-                " group by host.uuid";
+                " group by host.uuid order by cnt";
         TypedQuery<Tuple> q = dbf.getEntityManager().createQuery(sql, Tuple.class);
         q.setParameter("huuids", huuids);
-        logger.debug(huuids.stream().toString());
         return q.getResultList();
     }
 
@@ -49,13 +39,13 @@ public class LeastVmPreferredAllocatorFlow extends AbstractHostAllocatorFlow {
     public void allocate() {
         throwExceptionIfIAmTheFirstFlow();
 
-        List<String> huuids = getHostUuidsFromCandidates();
-        List<Tuple> tuples = findLeastVmHost(huuids);
-
         if (spec.isListAllHosts()) {
             next(candidates);
             return;
         }
+
+        List<String> huuids = getHostUuidsFromCandidates();
+        List<Tuple> tuples = findLeastVmHost(huuids);
 
         // no VM running on any candidate host(s)
         if (tuples.isEmpty()) {
@@ -63,46 +53,33 @@ public class LeastVmPreferredAllocatorFlow extends AbstractHostAllocatorFlow {
             return;
         }
 
+        List<HostVO> sorted = new ArrayList<>(candidates.size());
 
-        //
-        Map<String, VmNumHost> mp = new HashMap<>();
+        Map<String, HostVO> dict = new HashMap<>();
+        for (HostVO hvo: candidates) {
+            dict.put(hvo.getUuid(), hvo);
+        }
+
+        if (huuids.size() > tuples.size()) {
+            HashSet<String> hostsWithVMs = new HashSet<>();
+            for (Tuple t : tuples) {
+                String hostUuid = t.get(1, String.class);
+                hostsWithVMs.add(hostUuid);
+            }
+
+            for (String huuid : huuids) {
+                if (!hostsWithVMs.contains(huuid)) {
+                    sorted.add(dict.get(huuid));
+                }
+            }
+        }
+
+        // Note: the query result is ordered.
         for (Tuple t : tuples) {
-            long num = t.get(0, Long.class);
             String hostUuid = t.get(1, String.class);
-            VmNumHost vh = new VmNumHost();
-            vh.vmNum = num;
-            vh.hostUuid = hostUuid;
-            mp.put(hostUuid, vh);
+            sorted.add(dict.get(hostUuid));
         }
 
-        // for host not having vm running, put vm number to zero
-        for (String huuid : huuids) {
-            VmNumHost vh = mp.get(huuid);
-            if (vh == null) {
-                vh = new VmNumHost();
-                vh.hostUuid = huuid;
-                vh.vmNum = 0;
-                mp.put(huuid, vh);
-            }
-        }
-
-        long max = Integer.MAX_VALUE;
-        String huuid = null;
-        for (VmNumHost vh : mp.values()) {
-            if (vh.vmNum < max) {
-                huuid = vh.hostUuid;
-                max = vh.vmNum;
-            }
-        }
-
-        final String finalHuuid = huuid;
-        HostVO target = CollectionUtils.find(candidates, new Function<HostVO, HostVO>() {
-            @Override
-            public HostVO call(HostVO arg) {
-                return arg.getUuid().equals(finalHuuid) ? arg : null;
-            }
-        });
-
-        next(CollectionDSL.list(target));
+        next(sorted);
     }
 }

--- a/test/src/test/groovy/org/zstack/test/integration/kvm/hostallocator/AllocatorTest.groovy
+++ b/test/src/test/groovy/org/zstack/test/integration/kvm/hostallocator/AllocatorTest.groovy
@@ -1,0 +1,32 @@
+package org.zstack.test.integration.kvm.hostallocator
+
+import org.zstack.testlib.SpringSpec
+import org.zstack.testlib.Test
+
+/**
+ * Created by david on 3/6/17.
+ */
+class AllocatorTest extends Test {
+    static SpringSpec springSpec = makeSpring {
+        localStorage()
+        sftpBackupStorage()
+        kvm()
+        securityGroup()
+    }
+
+    @Override
+    void setup() {
+        useSpring(springSpec)
+    }
+
+    @Override
+    void environment() {
+    }
+
+    @Override
+    void test() {
+        runSubCases([
+                new LeastVmPreferredAllocatorCase()
+        ])
+    }
+}

--- a/test/src/test/groovy/org/zstack/test/integration/kvm/hostallocator/Env.groovy
+++ b/test/src/test/groovy/org/zstack/test/integration/kvm/hostallocator/Env.groovy
@@ -1,0 +1,253 @@
+package org.zstack.test.integration.kvm.hostallocator
+
+import org.zstack.network.securitygroup.SecurityGroupConstant
+import org.zstack.testlib.EnvSpec
+import org.zstack.testlib.Test
+import org.zstack.utils.data.SizeUnit
+
+/**
+ * Created by david on 3/6/17.
+ */
+class Env {
+    def DOC = """
+use:
+1. sftp backup storage
+2. local primary storage
+3. l2 novlan network
+4. security group
+5. 3 Host with 4 VM on a single host.
+
+This environment is modeled with the issue reported in #829.
+"""
+
+    static EnvSpec fourVmThreeHostEnv() {
+        return Test.makeEnv {
+            instanceOffering {
+                name = "instanceOffering"
+                memory = SizeUnit.GIGABYTE.toByte(2)
+                cpu = 2
+            }
+
+            sftpBackupStorage {
+                name = "sftp"
+                url = "/sftp"
+                username = "root"
+                password = "password"
+                hostname = "localhost"
+
+                image {
+                    name = "image1"
+                    url  = "http://zstack.org/download/test.qcow2"
+                }
+            }
+
+            zone {
+                name = "zone"
+                description = "test"
+
+                cluster {
+                    name = "cluster"
+                    hypervisorType = "KVM"
+
+                    kvm {
+                        name = "kvm1"
+                        managementIp = "127.0.0.2"
+                        username = "root"
+                        password = "password"
+
+                        totalCpu = 8
+                        totalMem = SizeUnit.GIGABYTE.toByte(10)
+                    }
+
+                    kvm {
+                        name = "kvm2"
+                        managementIp = "127.0.0.3"
+                        username = "root"
+                        password = "password"
+
+                        totalCpu = 8
+                        totalMem = SizeUnit.GIGABYTE.toByte(10)
+                    }
+
+                    kvm {
+                        name = "kvm2"
+                        managementIp = "127.0.0.4"
+                        username = "root"
+                        password = "password"
+
+                        totalCpu = 8
+                        totalMem = SizeUnit.GIGABYTE.toByte(10)
+                    }
+
+                    attachPrimaryStorage("local")
+                    attachL2Network("l2")
+                }
+
+                localPrimaryStorage {
+                    name = "local"
+                    url = "/local_ps"
+                }
+
+                l2NoVlanNetwork {
+                    name = "l2"
+                    physicalInterface = "eth0"
+
+                    l3Network {
+                        name = "l3"
+
+                        service {
+                            provider = SecurityGroupConstant.SECURITY_GROUP_PROVIDER_TYPE
+                            types = [SecurityGroupConstant.SECURITY_GROUP_NETWORK_SERVICE_TYPE]
+                        }
+
+                        ip {
+                            startIp = "192.168.100.10"
+                            endIp = "192.168.100.100"
+                            netmask = "255.255.255.0"
+                            gateway = "192.168.100.1"
+                        }
+                    }
+
+                    l3Network {
+                        name = "pubL3"
+
+                        ip {
+                            startIp = "12.16.10.10"
+                            endIp = "12.16.10.100"
+                            netmask = "255.255.255.0"
+                            gateway = "12.16.10.1"
+                        }
+                    }
+                }
+
+                attachBackupStorage("sftp")
+            }
+
+            vm {
+                name = "vm1"
+                useInstanceOffering("instanceOffering")
+                useImage("image1")
+                useL3Networks("l3")
+                useHost("kvm1")
+            }
+
+            vm {
+                name = "vm2"
+                useInstanceOffering("instanceOffering")
+                useImage("image1")
+                useL3Networks("l3")
+                useHost("kvm1")
+            }
+
+            vm {
+                name = "vm3"
+                useInstanceOffering("instanceOffering")
+                useImage("image1")
+                useL3Networks("l3")
+                useHost("kvm1")
+            }
+
+            vm {
+                name = "vm4"
+                useInstanceOffering("instanceOffering")
+                useImage("image1")
+                useL3Networks("l3")
+                useHost("kvm1")
+            }
+        }
+    }
+
+    static EnvSpec noHostBasicEnv() {
+        return Test.makeEnv {
+            instanceOffering {
+                name = "instanceOffering"
+                memory = SizeUnit.GIGABYTE.toByte(8)
+                cpu = 4
+            }
+
+            sftpBackupStorage {
+                name = "sftp"
+                url = "/sftp"
+                username = "root"
+                password = "password"
+                hostname = "localhost"
+
+                image {
+                    name = "image1"
+                    url  = "http://zstack.org/download/test.qcow2"
+                }
+
+                image {
+                    name = "vr"
+                    url  = "http://zstack.org/download/vr.qcow2"
+                }
+            }
+
+            zone {
+                name = "zone"
+                description = "test"
+
+                cluster {
+                    name = "cluster"
+                    hypervisorType = "KVM"
+
+                    attachPrimaryStorage("local")
+                    attachL2Network("l2")
+                }
+
+                localPrimaryStorage {
+                    name = "local"
+                    url = "/local_ps"
+                }
+
+                l2NoVlanNetwork {
+                    name = "l2"
+                    physicalInterface = "eth0"
+
+                    l3Network {
+                        name = "l3"
+
+                        service {
+                            provider = VirtualRouterConstant.PROVIDER_TYPE
+                            types = [NetworkServiceType.DHCP.toString(), NetworkServiceType.DNS.toString()]
+                        }
+
+                        service {
+                            provider = SecurityGroupConstant.SECURITY_GROUP_PROVIDER_TYPE
+                            types = [SecurityGroupConstant.SECURITY_GROUP_NETWORK_SERVICE_TYPE]
+                        }
+
+                        ip {
+                            startIp = "192.168.100.10"
+                            endIp = "192.168.100.100"
+                            netmask = "255.255.255.0"
+                            gateway = "192.168.100.1"
+                        }
+                    }
+
+                    l3Network {
+                        name = "pubL3"
+
+                        ip {
+                            startIp = "12.16.10.10"
+                            endIp = "12.16.10.100"
+                            netmask = "255.255.255.0"
+                            gateway = "12.16.10.1"
+                        }
+                    }
+                }
+
+                virtualRouterOffering {
+                    name = "vr"
+                    memory = SizeUnit.MEGABYTE.toByte(512)
+                    cpu = 2
+                    useManagementL3Network("pubL3")
+                    usePublicL3Network("pubL3")
+                    useImage("vr")
+                }
+
+                attachBackupStorage("sftp")
+            }
+        }
+    }
+}

--- a/test/src/test/groovy/org/zstack/test/integration/kvm/hostallocator/LeastVmPreferredAllocatorCase.groovy
+++ b/test/src/test/groovy/org/zstack/test/integration/kvm/hostallocator/LeastVmPreferredAllocatorCase.groovy
@@ -1,0 +1,78 @@
+package org.zstack.test.integration.kvm.hostallocator
+
+import org.zstack.kvm.KVMGlobalConfig
+import org.zstack.testlib.*
+/**
+ * Created by david on 3/6/17.
+ */
+class LeastVmPreferredAllocatorCase extends SubCase {
+    EnvSpec env
+
+    @Override
+    void clean() {
+        env.delete()
+    }
+
+    @Override
+    void setup() {
+        useSpring(AllocatorTest.springSpec)
+    }
+
+    @Override
+    void environment() {
+        env = Env.fourVmThreeHostEnv()
+    }
+
+    @Override
+    void test() {
+        env.create {
+            testCreateMulitpleVMs(8)
+        }
+    }
+
+    void testCreateMulitpleVMs(Long num) {
+        KVMGlobalConfig.RESERVED_MEMORY_CAPACITY.updateValue("2G")
+
+        // We have three hosts, each has 8 CPU and 10G memory.
+        // The reserved memory for each host is 1GB.
+        //   host1 has 4 VMs  (instance offering: 2 CPU, 2GB)
+        //   host2 has no VM
+        //   host3 has no VM
+        // We can still create 8 VMs in all, on host2 and host3, with the instance offering.
+        def thisImageUuid = (env.specByName("image1") as ImageSpec).inventory.uuid
+        def instOffering = (env.specByName("instanceOffering") as InstanceOfferingSpec).inventory.uuid
+        def l3uuid = (env.specByName("pubL3") as L3NetworkSpec).inventory.uuid
+
+        def threads = []
+        1.upto(num, {
+            def vmName = "VM-${it}"
+            def thread = Thread.start {
+                createVmInstance {
+                    name = vmName
+                    instanceOfferingUuid = instOffering
+                    imageUuid = thisImageUuid
+                    l3NetworkUuids = [l3uuid]
+                }
+            }
+
+            threads.add(thread)
+        })
+
+        threads.each{it.join()}
+
+        // We shall not be able to create another VM instance now
+        try {
+            createVmInstance {
+                name = "VMM"
+                instanceOfferingUuid = instOffering
+                imageUuid = thisImageUuid
+                l3NetworkUuids = [l3uuid]
+            }
+        } catch (AssertionError ignored) {
+            // Upon API failure, we have an assertion error in ApiHelper.groovy
+            return
+        }
+
+        assert false
+    }
+}


### PR DESCRIPTION
for https://github.com/zstackio/issues/issues/829

@ZStack-Robot 并发创建 VM 的时候，可能会有一部分创建失败。因为 `LeastVmPreferredAllocatorFlow` 只是返回了一台VM数量最少的主机。应该返回一个列表，按照VM数量从少到多排序。

Signed-off-by: David Lee <live4thee@gmail.com>