### PR TITLE
fix double '/' in log

### DIFF
--- a/core/src/main/java/org/zstack/core/ansible/AnsibleGlobalProperty.java
+++ b/core/src/main/java/org/zstack/core/ansible/AnsibleGlobalProperty.java
@@ -11,7 +11,7 @@ public class AnsibleGlobalProperty {
     public static String EXECUTABLE;
     @GlobalProperty(name = "Ansible.zstacklibPackageName", defaultValue = "zstacklib-1.9.tar.gz")
     public static String ZSTACKLIB_PACKAGE_NAME;
-    @GlobalProperty(name = "Ansible.zstackRoot", defaultValue = "/var/lib/zstack/")
+    @GlobalProperty(name = "Ansible.zstackRoot", defaultValue = "/var/lib/zstack")
     public static String ZSTACK_ROOT;
     @GlobalProperty(name = "Ansible.var.zstack_repo", defaultValue = "false")
     public static String ZSTACK_REPO;


### PR DESCRIPTION
After using sed， all the line that include ‘ansible’ and ‘var/lib/zstack’ have this bug，After investigation 
‘zstack_root’ is only be send by 'handle(final RunAnsibleMsg msg)' as args ，zstack-utility received and 
Spliced it   ('%s/xxx % zstack_root'). It haven't been used in other place.


   So approximately ensure  that it won't bring other problem and will fix this bug.


 
for https://github.com/zstackio/issues/issues/2281