### PR TITLE
[fix bug2413]getDataVolumeAttachableVm while PrimaryStorage is enable

### DIFF
--- a/storage/src/main/java/org/zstack/storage/volume/VolumeBase.java
+++ b/storage/src/main/java/org/zstack/storage/volume/VolumeBase.java
@@ -1066,8 +1066,9 @@ public class VolumeBase implements Volume {
                 List<String> hvTypes = VolumeFormat.valueOf(self.getFormat()).getHypervisorTypesSupportingThisVolumeFormatInString();
                 q.setParameter("hvTypes", hvTypes);
             } else if (self.getStatus() == VolumeStatus.NotInstantiated) {
-                sql = "select vm from VmInstanceVO vm where vm.state in (:vmStates) group by vm.uuid";
+                sql = "select vm from VmInstanceVO vm,PrimaryStorageClusterRefVO ref,PrimaryStorageEO ps where vm.state in (:vmStates) and vm.clusterUuid = ref.clusterUuid and ref.primaryStorageUuid = ps.uuid and ps.state in (:psState) group by vm.uuid";
                 q = dbf.getEntityManager().createQuery(sql, VmInstanceVO.class);
+                q.setParameter("psState",PrimaryStorageState.Enabled);
             } else {
                 DebugUtils.Assert(false, String.format("should not reach here, volume[uuid:%s]", self.getUuid()));
             }
@@ -1079,8 +1080,9 @@ public class VolumeBase implements Volume {
                 List<String> hvTypes = VolumeFormat.valueOf(self.getFormat()).getHypervisorTypesSupportingThisVolumeFormatInString();
                 q.setParameter("hvTypes", hvTypes);
             } else if (self.getStatus() == VolumeStatus.NotInstantiated) {
-                sql = "select vm from VmInstanceVO vm where vm.uuid in (:vmUuids) and vm.state in (:vmStates) group by vm.uuid";
+                sql = "select vm from VmInstanceVO vm,PrimaryStorageClusterRefVO ref,PrimaryStorageEO ps where vm.uuid in (:vmUuids) and vm.state in (:vmStates) and vm.clusterUuid = ref.clusterUuid and ref.primaryStorageUuid = ps.uuid and ps.state in (:psState) group by vm.uuid";
                 q = dbf.getEntityManager().createQuery(sql, VmInstanceVO.class);
+                q.setParameter("psState",PrimaryStorageState.Enabled);
             } else {
                 DebugUtils.Assert(false, String.format("should not reach here, volume[uuid:%s]", self.getUuid()));
             }
@@ -1098,7 +1100,6 @@ public class VolumeBase implements Volume {
         for (VolumeGetAttachableVmExtensionPoint ext : pluginRgty.getExtensionList(VolumeGetAttachableVmExtensionPoint.class)) {
             vms = ext.returnAttachableVms(vol, vms);
         }
-
         return vms;
     }
 

--- a/test/src/test/groovy/org/zstack/test/integration/storage/primary/local/LocalStorageMaintenanceVolumNotInstantiatedCase.groovy
+++ b/test/src/test/groovy/org/zstack/test/integration/storage/primary/local/LocalStorageMaintenanceVolumNotInstantiatedCase.groovy
@@ -1,0 +1,71 @@
+package org.zstack.test.integration.storage.primary.local
+
+import groovy.transform.TypeChecked
+import junit.framework.Assert
+import org.zstack.header.storage.primary.PrimaryStorageState
+import org.zstack.sdk.DiskOfferingInventory
+import org.zstack.sdk.PrimaryStorageInventory
+import org.zstack.sdk.VmInstanceInventory
+import org.zstack.sdk.VolumeInventory
+import org.zstack.test.integration.storage.Env
+import org.zstack.test.integration.storage.StorageTest
+import org.zstack.testlib.EnvSpec
+import org.zstack.testlib.SubCase
+import org.zstack.utils.Utils
+import org.zstack.utils.data.SizeUnit
+import org.zstack.utils.logging.CLogger
+
+import java.lang.reflect.Field
+
+/**
+ * Created by HeathHose on 2017/3/7.
+ */
+class LocalStorageMaintenanceVolumNotInstantiatedCase extends SubCase{
+    def DOC = """
+
+    GetDataVolumeAttachableVm don't list the vm which ps is maintain
+
+"""
+    EnvSpec env
+    private  final static CLogger logger = Utils.getLogger(LocalStorageMaintenanceVolumNotInstantiatedCase.class);
+    @Override
+    void setup() {
+        useSpring(StorageTest.springSpec)
+    }
+
+    @Override
+    void environment() {
+        env = Env.localStorageOneVmEnv()
+    }
+
+    @Override
+    void test() {
+        env.create{
+            testListAvailableVmWhenPrimaryStorageisMaintenance()
+        }
+
+    }
+
+    void testListAvailableVmWhenPrimaryStorageisMaintenance(){
+        DiskOfferingInventory diskOffering = env.inventoryByName("diskOffering")
+        PrimaryStorageInventory primaryStorage = env.inventoryByName("local")
+
+        VolumeInventory volumeInventory = createDataVolume {
+            name = "volume1"
+            diskOfferingUuid = diskOffering.uuid
+        }
+        primaryStorage = changePrimaryStorageState {
+            uuid=primaryStorage.uuid
+            stateEvent = "maintain"
+        }
+        List<VmInstanceInventory> list = getDataVolumeAttachableVm {
+            volumeUuid = volumeInventory.uuid
+        }
+        assert list.isEmpty() == true
+    }
+
+    @Override
+    void clean() {
+        env.delete()
+    }
+}


### PR DESCRIPTION
@ZStack-Robot 
List availableVm When PrimaryStorage is Maintenance 
https://github.com/zstackio/issues/issues/2413