### PR TITLE
bugfix - VmInstanceBase.selectDefaultL3() find VmNicVO

### DIFF
--- a/compute/src/main/java/org/zstack/compute/vm/VmInstanceBase.java
+++ b/compute/src/main/java/org/zstack/compute/vm/VmInstanceBase.java
@@ -2930,7 +2930,7 @@ public class VmInstanceBase extends AbstractVmInstance {
         final VmNicVO candidate = CollectionUtils.find(self.getVmNics(), new Function<VmNicVO, VmNicVO>() {
             @Override
             public VmNicVO call(VmNicVO arg) {
-                return arg.getL3NetworkUuid().equals(nic.getUuid()) ? null : arg;
+                return arg.getUuid().equals(nic.getUuid()) ? null : arg;
             }
         });
 


### PR DESCRIPTION
arg.getUuid() instead of arg.getL3NetworkUuid()