### PR TITLE
add unicode encode when add ceph pool

### DIFF
--- a/plugin/ceph/src/main/java/org/zstack/storage/ceph/primary/CephPrimaryStorageBase.java
+++ b/plugin/ceph/src/main/java/org/zstack/storage/ceph/primary/CephPrimaryStorageBase.java
@@ -62,6 +62,7 @@ import org.zstack.utils.Utils;
 import org.zstack.utils.function.Function;
 import org.zstack.utils.gson.JSONObjectUtil;
 import org.zstack.utils.logging.CLogger;
+import org.zstack.utils.EncodingConversion;
 
 import static org.zstack.core.Platform.i18n;
 import static org.zstack.core.Platform.operr;
@@ -2214,7 +2215,7 @@ public class CephPrimaryStorageBase extends PrimaryStorageBase {
 
         AddPoolCmd cmd = new AddPoolCmd();
         cmd.errorIfNotExist = msg.isErrorIfNotExist();
-        cmd.poolName = msg.getPoolName();
+        cmd.poolName = EncodingConversion.encodingToUnicode(msg.getPoolName());
 
         APIAddCephPrimaryStoragePoolEvent evt = new APIAddCephPrimaryStoragePoolEvent(msg.getId());
         CephPrimaryStoragePoolVO finalVo = vo;

--- a/test/src/test/groovy/org/zstack/test/integration/storage/primary/ceph/CephPrimaryStorageVolumePoolsCase.groovy
+++ b/test/src/test/groovy/org/zstack/test/integration/storage/primary/ceph/CephPrimaryStorageVolumePoolsCase.groovy
@@ -10,6 +10,7 @@ import org.zstack.storage.ceph.primary.CephPrimaryStoragePoolVO
 import org.zstack.storage.ceph.primary.CephPrimaryStoragePoolVO_
 import org.zstack.test.integration.storage.StorageTest
 import org.zstack.testlib.*
+import org.zstack.utils.EncodingConversion
 import org.zstack.utils.data.SizeUnit
 
 /**
@@ -171,7 +172,7 @@ class CephPrimaryStorageVolumePoolsCase extends SubCase {
         assert inv.poolName == LOW_POOL_NAME
         assert acmd != null
         assert !acmd.errorIfNotExist
-        assert acmd.poolName == LOW_POOL_NAME
+        assert acmd.poolName == EncodingConversion.encodingToUnicode(LOW_POOL_NAME)
 
         CephPrimaryStorageBase.DeletePoolCmd dcmd = null
 

--- a/utils/src/main/java/org/zstack/utils/EncodingConversion.java
+++ b/utils/src/main/java/org/zstack/utils/EncodingConversion.java
@@ -1,0 +1,18 @@
+package org.zstack.utils;
+
+/**
+ * Created by Administrator on 2017-04-01.
+ */
+public class EncodingConversion {
+    public static String encodingToUnicode(String str){
+        StringBuffer buf = new StringBuffer(str.length()*6);
+        buf.setLength(0);
+
+        for (int i = 0; i < str.length(); i++) {
+            char c = str.charAt(i);
+            String tmp = Integer.toHexString(c + 0x10000).substring(1);
+            buf.append("\\u").append(tmp);
+        }
+        return (new String(buf));
+    }
+}


### PR DESCRIPTION
agent cannot load Chinese words directly, so send Unicode then encode it in agent.  
 for https://github.com/zstackio/issues/issues/2527 