### PR TITLE
fix case

### DIFF
--- a/test/src/test/groovy/org/zstack/test/integration/core/CoreLibraryTest.groovy
+++ b/test/src/test/groovy/org/zstack/test/integration/core/CoreLibraryTest.groovy
@@ -1,7 +1,5 @@
 package org.zstack.test.integration.core
 
-import org.zstack.test.integration.core.gc.EventBasedGarbageCollectorCase
-import org.zstack.test.integration.core.gc.TimeBasedGarbageCollectorCase
 import org.zstack.testlib.Test
 
 /**
@@ -10,7 +8,6 @@ import org.zstack.testlib.Test
 class CoreLibraryTest extends Test {
     @Override
     void setup() {
-        INCLUDE_CORE_SERVICES = false
         spring {
             include("CloudBusAopProxy.xml")
             include("JobForUnitTest.xml")


### PR DESCRIPTION
大多数的pr中，由case : `SchedulerCase` 在test suite中发生。初步断定为缺少部分组件引起。

修改相应的代码后，不再出现这种问题。