### PR TITLE
fix bug 1264

### DIFF
--- a/conf/db/upgrade/V1.11__schema.sql
+++ b/conf/db/upgrade/V1.11__schema.sql
@@ -637,4 +637,8 @@ ALTER TABLE LocalStorageResourceRefVO DROP FOREIGN KEY `fkLocalStorageResourceRe
 
 ALTER TABLE VipVO ADD CONSTRAINT fkUsedIpVO FOREIGN KEY (`usedIpUuid`) REFERENCES `UsedIpVO` (`uuid`) ON DELETE CASCADE;
 
+
 ALTER TABLE VCenterVO ADD port int DEFAULT NULL;
+
+ALTER TABLE SharedResourceVO DROP FOREIGN KEY `fkSharedResourceVOAccountVO1`;
+

--- a/header/src/main/java/org/zstack/header/identity/SharedResourceVO.java
+++ b/header/src/main/java/org/zstack/header/identity/SharedResourceVO.java
@@ -22,7 +22,6 @@ public class SharedResourceVO {
     private String ownerAccountUuid;
 
     @Column
-    @ForeignKey(parentEntityClass = AccountVO.class, onDeleteAction = ReferenceOption.CASCADE)
     private String receiverAccountUuid;
 
     @Column

--- a/identity/src/main/java/org/zstack/identity/AccountBase.java
+++ b/identity/src/main/java/org/zstack/identity/AccountBase.java
@@ -466,6 +466,10 @@ public class AccountBase extends AbstractAccount {
             for (String ruuid : msg.getResourceUuids()) {
                 SharedResourceVO svo = new SharedResourceVO();
                 svo.setOwnerAccountUuid(msg.getAccountUuid());
+                //if ReceiverAccountUuid is null, entity might duplicate even there is unique index，
+                //so we set it the "*" to avoid it.
+                //and modify foreign key to trigger
+                svo.setReceiverAccountUuid("*");
                 svo.setResourceType(uuidType.get(ruuid));
                 svo.setResourceUuid(ruuid);
                 svo.setToPublic(true);


### PR DESCRIPTION
if ReceiverAccountUuid is null, entity might duplicate even there is unique index，
so we set it “*” to avoid it.
and modify foreign key to trigger
deploy test pass
 for https://github.com/zstackio/issues/issues/1264