### PR TITLE
fix case

### DIFF
--- a/test/src/test/groovy/org/zstack/test/integration/kvm/host/CpuMemoryCapacityCase.groovy
+++ b/test/src/test/groovy/org/zstack/test/integration/kvm/host/CpuMemoryCapacityCase.groovy
@@ -1,0 +1,123 @@
+package org.zstack.test.integration.kvm.host
+
+import org.springframework.http.HttpEntity
+import org.zstack.compute.host.HostGlobalConfig
+import org.zstack.core.db.Q
+import org.zstack.header.host.HostStatus
+import org.zstack.header.host.HostVO
+import org.zstack.header.host.HostVO_
+import org.zstack.kvm.KVMAgentCommands
+import org.zstack.kvm.KVMConstant
+import org.zstack.kvm.KVMGlobalConfig
+import org.zstack.sdk.GetCpuMemoryCapacityAction
+import org.zstack.sdk.HostInventory
+import org.zstack.sdk.ReconnectHostAction
+import org.zstack.test.integration.kvm.KvmTest
+import org.zstack.test.integration.kvm.hostallocator.AllocatorTest
+import org.zstack.test.integration.kvm.hostallocator.Env
+import org.zstack.testlib.EnvSpec
+import org.zstack.testlib.HostSpec
+import org.zstack.testlib.SubCase
+import org.zstack.utils.SizeUtils
+import org.zstack.utils.gson.JSONObjectUtil
+
+/**
+ * Created by camile on 2017/4/10.
+ */
+class CpuMemoryCapacityCase extends SubCase {
+    EnvSpec env
+
+    @Override
+    void clean() {
+        env.delete()
+    }
+
+    @Override
+    void setup() {
+        useSpring(AllocatorTest.springSpec)
+        useSpring(KvmTest.springSpec)
+    }
+
+    @Override
+    void environment() {
+        env = Env.noVmThreeHostEnv()
+    }
+
+    @Override
+    void test() {
+        env.create {
+            KVMGlobalConfig.RESERVED_MEMORY_CAPACITY.updateValue("1G")
+            HostGlobalConfig.AUTO_RECONNECT_ON_ERROR.updateValue(false)
+            HostGlobalConfig.PING_HOST_INTERVAL.updateValue(5)
+            setHostDisconnecedAndGetCorrectlyCpuMemoryCapacity()
+        }
+    }
+
+    void setHostDisconnecedAndGetCorrectlyCpuMemoryCapacity() {
+        GetCpuMemoryCapacityAction action = new GetCpuMemoryCapacityAction()
+        action.all = true
+        action.sessionId = adminSession()
+        GetCpuMemoryCapacityAction.Result res = action.call()
+        assert res.error == null
+        long result = res.value.availableMemory
+        assert result == SizeUtils.sizeStringToBytes("27G")
+
+        HostInventory kvm1Inv = (env.specByName("kvm1") as HostSpec).inventory
+        HostInventory kvm2Inv = (env.specByName("kvm2") as HostSpec).inventory
+        HostInventory kvm3Inv = (env.specByName("kvm3") as HostSpec).inventory
+
+        KVMAgentCommands.ReconnectMeCmd reconnectMeCmd = null
+        KVMAgentCommands.ConnectCmd connectCmd = null
+        env.afterSimulator(KVMConstant.KVM_CONNECT_PATH) { KVMAgentCommands.AgentResponse rsp, HttpEntity<String> e ->
+            connectCmd = JSONObjectUtil.toObject(e.body, KVMAgentCommands.ConnectCmd.class)
+            rsp.success = false
+            if (connectCmd.hostUuid == kvm3Inv.uuid) {
+                rsp.success = true
+            }
+            return rsp
+        }
+        KVMAgentCommands.ReconnectMeCmd reConnectCmd = null
+        env.afterSimulator(KVMConstant.KVM_RECONNECT_ME) { KVMAgentCommands.AgentResponse rsp, HttpEntity<String> e ->
+            reConnectCmd = JSONObjectUtil.toObject(e.body, KVMAgentCommands.ReconnectMeCmd.class)
+            rsp.success = false
+            if ((reconnectMeCmd.hostUuid == kvm3Inv.uuid)) {
+                rsp.success = true
+            }
+            return rsp
+        }
+
+
+        ReconnectHostAction reconnectHostAction = new ReconnectHostAction()
+        reconnectHostAction.uuid = kvm1Inv.uuid
+        reconnectHostAction.sessionId = adminSession()
+        ReconnectHostAction.Result reconnectRes = reconnectHostAction.call()
+        reconnectRes.error !=null
+        reconnectHostAction.uuid = kvm2Inv.uuid
+        reconnectRes = reconnectHostAction.call()
+        reconnectRes.error !=null
+
+        retryInSecs{
+            return {
+                assert Q.New(HostVO.class).select(HostVO_.status).eq(HostVO_.uuid, kvm1Inv.uuid).findValue().toString() == HostStatus.Disconnected.toString()
+                assert Q.New(HostVO.class).select(HostVO_.status).eq(HostVO_.uuid, kvm2Inv.uuid).findValue().toString() == HostStatus.Disconnected.toString()
+            }
+        }
+        if (Q.New(HostVO.class).select(HostVO_.status).eq(HostVO_.uuid, kvm3Inv.uuid).findValue().toString() != HostStatus.Connected.toString()) {
+            reconnectHost {
+                uuid = kvm3Inv.uuid
+            }
+        }
+        retryInSecs{
+            return {
+                assert Q.New(HostVO.class).select(HostVO_.status).eq(HostVO_.uuid, kvm3Inv.uuid).findValue().toString() == HostStatus.Connected.toString()
+            }
+        }
+
+        res = action.call()
+        assert res.error == null
+        result = res.value.availableMemory
+        assert result == SizeUtils.sizeStringToBytes("9G")
+    }
+
+
+}


### PR DESCRIPTION
之前的case尝试从pingKvm入手，期待结果是将三台host中的两台置为失联，但是结果不是很稳定（以之前的情况来说，三台全部失联），并且异常堆栈也被吃掉了，没有提供更为详情的信息。比如：
~~~
^[[m^[[37m2017-04-21 19:57:07,070 TRACE [SimpleFlowChain] {} execution path:
class org.zstack.kvm.KVMHost$42$1[KVMHost.java:ping-host] -->
class org.zstack.kvm.KVMHost$42$2[KVMHost.java:call-ping-no-failure-plugins] -->
class org.zstack.kvm.KVMHost$42$3[KVMHost.java:call-ping-plugins]
^[[m^[[37m2017-04-21 19:57:07,070 DEBUG [SimpleFlowChain] {} [FlowChain: ping-kvm-host-57cac0f2925647bb8bd0fbf58d073020] start executing flow[KVMHost.java:ping-host]
^[[m^[[37m2017-04-21 19:57:07,072 TRACE [RESTFacadeImpl] {} json post[http://127.0.0.4:8989/host/ping], <{"hostUuid":"31ed936ac5c74109a66040278c0c57c4"},{Content-Type=[application/json], Content-Length=[47], taskuuid=[32e8d4faa8ca4dc0ba03f6dce9079ad8], callbackurl=[http://localhost:8989/asyncrest/callback]}>
^[[m^[[37m2017-04-21 19:57:07,072 TRACE [RESTFacadeImpl] {} json post[http://127.0.0.3:8989/host/ping], <{"hostUuid":"7a4b65937f884f208108d9206cd8585e"},{Content-Type=[application/json], Content-Length=[47], taskuuid=[8edf7c725b8b47549219981f1474a183], callbackurl=[http://localhost:8989/asyncrest/callback]}>
^[[m^[[37m2017-04-21 19:57:07,072 TRACE [RESTFacadeImpl] {} json post[http://127.0.0.2:8989/host/ping], <{"hostUuid":"57cac0f2925647bb8bd0fbf58d073020"},{Content-Type=[application/json], Content-Length=[47], taskuuid=[0d0380f6978a4ba782cdfda4d5da1c50], callbackurl=[http://localhost:8989/asyncrest/callback]}>
^[[m^[[37m2017-04-21 19:57:07,086 TRACE [RESTFacadeImpl] {} [http response(url: http://127.0.0.4:8989/host/ping, taskUuid: 32e8d4faa8ca4dc0ba03f6dce9079ad8)] {"hostUuid":"57cac0f2925647bb8bd0fbf58d073020","success":false}
^[[m^[[37m2017-04-21 19:57:07,086 TRACE [RESTFacadeImpl] {} [http response(url: http://127.0.0.3:8989/host/ping, taskUuid: 8edf7c725b8b47549219981f1474a183)] {"hostUuid":"7a4b65937f884f208108d9206cd8585e","success":false}
^[[m^[[37m2017-04-21 19:57:07,087 DEBUG [DebugUtils] {} An error code{"code":"SYS.1000","description":"An internal error happened in system"} is instantiated, for tracing the place error happened, dump stack as below:
        java.lang.Thread.getStackTrace(Thread.java:1556)
        org.zstack.utils.DebugUtils.getStackTrace(DebugUtils.java:73)
        org.zstack.utils.DebugUtils.dumpStackTrace(DebugUtils.java:83)
        org.zstack.core.errorcode.ErrorFacadeImpl.doInstantiateErrorCode(ErrorFacadeImpl.java:68)
        org.zstack.core.errorcode.ErrorFacadeImpl.instantiateErrorCode(ErrorFacadeImpl.java:77)
        org.zstack.core.errorcode.ErrorFacadeImpl.throwableToInternalError(ErrorFacadeImpl.java:87)
        org.zstack.core.aspect.AsyncBackupAspect.backup(AsyncBackupAspect.aj:55)
        org.zstack.core.aspect.AsyncBackupAspect.backup(AsyncBackupAspect.aj:86) org.zstack.core.aspect.AsyncBackupAspect.ajc$inlineAccessMethod$org_zstack_core_aspect_AsyncBackupAspect$org_zstack_core_aspect_AsyncBackupAspect$backup(AsyncBackupAspect.aj:1)
        org.zstack.core.aspect.AsyncBackupAspect.ajc$around$org_zstack_core_aspect_AsyncBackupAspect$12$2d069f6a(AsyncBackupAspect.aj:181)
        org.zstack.kvm.KVMHost$42$1$1.success(KVMHost.java:2184)
        org.zstack.kvm.KVMHost$42$1$1.success(KVMHost.java:1)
        org.zstack.core.rest.RESTFacadeImpl$1.success_aroundBody0(RESTFacadeImpl.java:307)
        org.zstack.core.rest.RESTFacadeImpl$1$AjcClosure1.run(RESTFacadeImpl.java:1)
        org.zstack.core.aspect.ThreadAspect.ajc$around$org_zstack_core_aspect_ThreadAspect$4$de40e327proceed(ThreadAspect.aj:141)
        org.zstack.core.aspect.ThreadAspect$ThreadAspect$4.call(ThreadAspect.aj:145)
        org.zstack.core.aspect.ThreadAspect$ThreadAspect$4.call(ThreadAspect.aj:1)
        org.zstack.core.thread.ThreadFacadeImpl$Worker.call(ThreadFacadeImpl.java:113)
        java.util.concurrent.FutureTask.run(FutureTask.java:266)
        java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$201(ScheduledThreadPoolExecutor.java:180)
        java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
        java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
        java.lang.Thread.run(Thread.java:745)

^[[m^[[37m2017-04-21 19:57:07,087 DEBUG [SimpleFlowChain] {} [FlowChain: ping-kvm-host-7a4b65937f884f208108d9206cd8585e] start to rollback
^[[m^[[37m2017-04-21 19:57:07,088 DEBUG [SimpleFlowChain] {} [FlowChain: ping-kvm-host-7a4b65937f884f208108d9206cd8585e] start to rollback flow[KVMHost.java:ping-host]
^[[m^[[37m2017-04-21 19:57:07,088 DEBUG [SimpleFlowChain] {} [FlowChain: ping-kvm-host-7a4b65937f884f208108d9206cd8585e] rolled back all flows because error{"code":"SYS.1000","description":"An internal error happened in system"}
^[[m^[[37m2017-04-21 19:57:07,088 TRACE [RESTFacadeImpl] {} [http response(url: http://127.0.0.2:8989/host/ping, taskUuid: 0d0380f6978a4ba782cdfda4d5da1c50)] {"hostUuid":"57cac0f2925647bb8bd0fbf58d073020","success":false}
^[[m^[[37m2017-04-21 19:57:07,088 DEBUG [DebugUtils] {} An error code{"code":"SYS.1000","description":"An internal error happened in system"} is instantiated, for tracing the place error happened, dump stack as below:
        java.lang.Thread.getStackTrace(Thread.java:1556)
        org.zstack.utils.DebugUtils.getStackTrace(DebugUtils.java:73)
        org.zstack.utils.DebugUtils.dumpStackTrace(DebugUtils.java:83)
        org.zstack.core.errorcode.ErrorFacadeImpl.doInstantiateErrorCode(ErrorFacadeImpl.java:68)
        org.zstack.core.errorcode.ErrorFacadeImpl.instantiateErrorCode(ErrorFacadeImpl.java:77)
        org.zstack.core.errorcode.ErrorFacadeImpl.throwableToInternalError(ErrorFacadeImpl.java:87)
        org.zstack.core.aspect.AsyncBackupAspect.backup(AsyncBackupAspect.aj:55)
        org.zstack.core.aspect.AsyncBackupAspect.backup(AsyncBackupAspect.aj:86)
        org.zstack.core.aspect.AsyncBackupAspect.ajc$inlineAccessMethod$org_zstack_core_aspect_AsyncBackupAspect$org_zstack_core_aspect_AsyncBackupAspect$backup(AsyncBackupAspect.aj:1)
        org.zstack.core.aspect.AsyncBackupAspect.ajc$around$org_zstack_core_aspect_AsyncBackupAspect$12$2d069f6a(AsyncBackupAspect.aj:181)
        org.zstack.kvm.KVMHost$42$1$1.success(KVMHost.java:2184)
        org.zstack.kvm.KVMHost$42$1$1.success(KVMHost.java:1)
        org.zstack.core.rest.RESTFacadeImpl$1.success_aroundBody0(RESTFacadeImpl.java:307)
        org.zstack.core.rest.RESTFacadeImpl$1$AjcClosure1.run(RESTFacadeImpl.java:1)
        org.zstack.core.aspect.ThreadAspect.ajc$around$org_zstack_core_aspect_ThreadAspect$4$de40e327proceed(ThreadAspect.aj:141)
        org.zstack.core.aspect.ThreadAspect$ThreadAspect$4.call(ThreadAspect.aj:145)
        org.zstack.core.aspect.ThreadAspect$ThreadAspect$4.call(ThreadAspect.aj:1)
        org.zstack.core.thread.ThreadFacadeImpl$Worker.call(ThreadFacadeImpl.java:113)
        java.util.concurrent.FutureTask.run(FutureTask.java:266)
        java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$201(ScheduledThreadPoolExecutor.java:180)
        java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:293)
        java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
        java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
        java.lang.Thread.run(Thread.java:745)
~~~

KVMHost的2184行代码大致 如下：
~~~
     FlowChain chain = FlowChainBuilder.newShareFlowChain();
        chain.setName(String.format("ping-kvm-host-%s", self.getUuid()));
        chain.then(new ShareFlow() {
            @Override
            public void setup() {
                flow(new NoRollbackFlow() {
                    String __name__ = "ping-host";

                    @AfterDone
                    List<Runnable> afterDone = new ArrayList<>();

                    @Override
                    public void run(FlowTrigger trigger, Map data) {
                        PingCmd cmd = new PingCmd();
                        cmd.hostUuid = self.getUuid();
                        restf.asyncJsonPost(pingPath, cmd, new JsonAsyncRESTCallback<PingResponse>(trigger) {
                            @Override
                            public void fail(ErrorCode err) {
                                trigger.fail(err);
                            }

                            @Override
                            public void success(PingResponse ret) { //2184行
                                if (ret.isSuccess()) {
                                    if (!self.getUuid().equals(ret.getHostUuid())) {
                                        afterDone.add(() -> {
                                            String info = String.format("detected abnormal status[host uuid change, expected: %s but: %s] of kvmagent," +
                                                    "it's mainly caused by kvmagent restarts behind zstack management server. Report this to ping task, it will issue a reconnect soon", self.getUuid(), ret.getHostUuid());
                                            logger.warn(info);
                                            ReconnectHostMsg rmsg = new ReconnectHostMsg();
                                            rmsg.setHostUuid(self.getUuid());
                                            bus.makeTargetServiceIdByResourceUuid(rmsg, HostConstant.SERVICE_ID, self.getUuid());
                                            bus.send(rmsg);
                                        });
                                    }
~~~

因为没有一个详细的报错信息，花了较长的时间去猜测以及尝试了各种方案（为保证稳定性，每次修改至少跑20遍以上）后。**现解决方案是主动触发失联。**