### PR TITLE
fix bug 2756 if nfs url is not valid, update url will fail

### DIFF
--- a/conf/serviceConfig/primaryStorage.xml
+++ b/conf/serviceConfig/primaryStorage.xml
@@ -62,6 +62,8 @@
 
     <message>
         <name>org.zstack.header.storage.primary.APIUpdatePrimaryStorageMsg</name>
+        <interceptor>PrimaryStorageApiInterceptor</interceptor>
+        <interceptor>NfsPrimaryStorageApiInterceptor</interceptor>
     </message>
 
     <message>

--- a/plugin/nfsPrimaryStorage/src/main/java/org/zstack/storage/primary/nfs/NfsApiParamChecker.java
+++ b/plugin/nfsPrimaryStorage/src/main/java/org/zstack/storage/primary/nfs/NfsApiParamChecker.java
@@ -2,6 +2,7 @@ package org.zstack.storage.primary.nfs; /**
  * Created by xing5 on 2016/8/19.
  */
 
+import org.apache.commons.lang.StringUtils;
 import org.springframework.beans.factory.annotation.Autowire;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Configurable;
@@ -9,11 +10,21 @@ import org.zstack.core.db.DatabaseFacade;
 import org.zstack.core.db.SimpleQuery;
 import org.zstack.core.db.SimpleQuery.Op;
 import org.zstack.core.errorcode.ErrorFacade;
+import org.zstack.header.apimediator.ApiMessageInterceptionException;
 import org.zstack.header.errorcode.ErrorCode;
 import org.zstack.header.errorcode.SysErrors;
+import org.zstack.header.storage.primary.APIUpdatePrimaryStorageMsg;
 import org.zstack.header.storage.primary.PrimaryStorageVO;
 import org.zstack.header.storage.primary.PrimaryStorageVO_;
+import org.zstack.header.vm.VmInstanceState;
+
+import javax.persistence.Tuple;
+import javax.persistence.TypedQuery;
+import java.util.List;
+import java.util.stream.Collectors;
+
 import static org.zstack.core.Platform.argerr;
+import static org.zstack.core.Platform.operr;
 
 @Configurable(preConstruction = true, autowire = Autowire.BY_TYPE)
 public class NfsApiParamChecker {
@@ -22,15 +33,28 @@ public class NfsApiParamChecker {
     @Autowired
     private ErrorFacade errf;
 
-    public ErrorCode checkUrl(String zoneUuid, String url) {
+    public void checkUrl(String zoneUuid, String url) {
         SimpleQuery<PrimaryStorageVO> q = dbf.createQuery(PrimaryStorageVO.class);
         q.add(PrimaryStorageVO_.type, Op.EQ, NfsPrimaryStorageConstant.NFS_PRIMARY_STORAGE_TYPE);
         q.add(PrimaryStorageVO_.url, Op.EQ, url);
         q.add(PrimaryStorageVO_.zoneUuid, Op.EQ, zoneUuid);
         if (q.isExists()) {
-            return argerr("there has been a nfs primary storage having url as %s in zone[uuid:%s]", url, zoneUuid);
-        } else {
-            return null;
+            throw new ApiMessageInterceptionException(argerr("there has been a nfs primary storage having url as %s in zone[uuid:%s]", url, zoneUuid));
+        }
+    }
+
+    public void checkRunningVmForUpdateUrl(String psuuid) {
+        String sql = "select vm.name, vm.uuid from VmInstanceVO vm, VolumeVO vol where vm.uuid = vol.vmInstanceUuid and" +
+                " vol.primaryStorageUuid = :psUuid and vm.state = :vmState";
+        TypedQuery<Tuple> q = dbf.getEntityManager().createQuery(sql, Tuple.class);
+        q.setParameter("psUuid", psuuid);
+        q.setParameter("vmState", VmInstanceState.Running);
+        List<Tuple> ts = q.getResultList();
+
+        if (!ts.isEmpty()) {
+            List<String> vms = ts.stream().map(v -> String.format("VM[name:%s, uuid:%s]", v.get(0, String.class), v.get(1, String.class))).collect(Collectors.toList());
+            throw new ApiMessageInterceptionException(operr("there are %s running VMs on the NFS primary storage, please" +
+                    " stop them and try again:\n%s\n", vms.size(), StringUtils.join(vms, "\n")));
         }
     }
 }

--- a/plugin/nfsPrimaryStorage/src/main/java/org/zstack/storage/primary/nfs/NfsPrimaryStorageApiInterceptor.java
+++ b/plugin/nfsPrimaryStorage/src/main/java/org/zstack/storage/primary/nfs/NfsPrimaryStorageApiInterceptor.java
@@ -1,12 +1,28 @@
 package org.zstack.storage.primary.nfs;
 
+import org.apache.commons.lang.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
 import org.zstack.core.db.DatabaseFacade;
+import org.zstack.core.db.Q;
+import org.zstack.core.db.SQLBatch;
 import org.zstack.core.errorcode.ErrorFacade;
 import org.zstack.header.apimediator.ApiMessageInterceptionException;
 import org.zstack.header.apimediator.ApiMessageInterceptor;
 import org.zstack.header.errorcode.ErrorCode;
+import org.zstack.header.errorcode.OperationFailureException;
 import org.zstack.header.message.APIMessage;
+import org.zstack.header.storage.primary.APIUpdatePrimaryStorageMsg;
+import org.zstack.header.storage.primary.PrimaryStorageVO;
+import org.zstack.header.storage.primary.PrimaryStorageVO_;
+import org.zstack.header.vm.VmInstanceState;
+
+import javax.persistence.Tuple;
+import javax.persistence.TypedQuery;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.zstack.core.Platform.operr;
 
 import static org.zstack.core.Platform.argerr;
 
@@ -22,20 +38,47 @@ public class NfsPrimaryStorageApiInterceptor implements ApiMessageInterceptor {
     public APIMessage intercept(APIMessage msg) throws ApiMessageInterceptionException {
         if (msg instanceof APIAddNfsPrimaryStorageMsg) {
             validate((APIAddNfsPrimaryStorageMsg) msg);
+        }else if(msg instanceof APIUpdatePrimaryStorageMsg){
+            validate((APIUpdatePrimaryStorageMsg) msg);
         }
 
         return msg;
     }
 
     private void validate(APIAddNfsPrimaryStorageMsg msg) {
-        ErrorCode err = new NfsApiParamChecker().checkUrl(msg.getZoneUuid(), msg.getUrl());
-        if (err != null) {
-            throw new ApiMessageInterceptionException(err);
-        }
+        new NfsApiParamChecker().checkUrl(msg.getZoneUuid(), msg.getUrl());
         String[] results = msg.getUrl().split(":");
         if (results.length == 2 && (
                 results[1].startsWith("/dev") || results[1].startsWith("/proc") || results[1].startsWith("/sys"))) {
             throw new ApiMessageInterceptionException(argerr(" the url contains an invalid folder[/dev or /proc or /sys]"));
         }
     }
+
+    private void validate(APIUpdatePrimaryStorageMsg msg){
+        Tuple t = Q.New(PrimaryStorageVO.class)
+                .select(PrimaryStorageVO_.type, PrimaryStorageVO_.url, PrimaryStorageVO_.zoneUuid)
+                .eq(PrimaryStorageVO_.uuid, msg.getUuid())
+                .findTuple();
+
+        String type = t.get(0, String.class);
+        String url = t.get(1, String.class);
+        String zoneUuid = t.get(2, String.class);
+        if(!type.equals(NfsPrimaryStorageConstant.NFS_PRIMARY_STORAGE_TYPE)){
+            return;
+        }
+
+        if (msg.getUrl() != null && !msg.getUrl().equals(url)){
+            new SQLBatch(){
+                @Override
+                protected void scripts() {
+                    NfsApiParamChecker checker = new NfsApiParamChecker();
+                    checker.checkUrl(zoneUuid, msg.getUrl());
+                    checker.checkRunningVmForUpdateUrl(msg.getUuid());
+                }
+            }.execute();
+        }
+    }
+
+
+
 }

--- a/plugin/nfsPrimaryStorage/src/main/java/org/zstack/storage/primary/nfs/NfsPrimaryStorageBackend.java
+++ b/plugin/nfsPrimaryStorage/src/main/java/org/zstack/storage/primary/nfs/NfsPrimaryStorageBackend.java
@@ -29,7 +29,7 @@ public interface NfsPrimaryStorageBackend {
 
     void checkIsBitsExisting(PrimaryStorageInventory inv, String installPath, ReturnValueCompletion<Boolean> completion);
 
-    boolean attachToCluster(PrimaryStorageInventory inv, String clusterUuid) throws NfsPrimaryStorageException;
+    void attachToCluster(PrimaryStorageInventory inv, String clusterUuid, ReturnValueCompletion<Boolean> completion);
 
     void detachFromCluster(PrimaryStorageInventory inv, String clusterUuid) throws NfsPrimaryStorageException;
 

--- a/plugin/nfsPrimaryStorage/src/main/java/org/zstack/storage/primary/nfs/NfsPrimaryStorageKVMBackend.java
+++ b/plugin/nfsPrimaryStorage/src/main/java/org/zstack/storage/primary/nfs/NfsPrimaryStorageKVMBackend.java
@@ -5,6 +5,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.zstack.core.CoreGlobalProperty;
 import org.zstack.core.asyncbatch.AsyncBatchRunner;
 import org.zstack.core.asyncbatch.LoopAsyncBatch;
+import org.zstack.core.asyncbatch.While;
 import org.zstack.core.cloudbus.CloudBus;
 import org.zstack.core.cloudbus.CloudBusCallBack;
 import org.zstack.core.cloudbus.CloudBusListCallBack;
@@ -16,6 +17,7 @@ import org.zstack.core.errorcode.schema.Error;
 import org.zstack.core.logging.Log;
 import org.zstack.core.timeout.ApiTimeoutManager;
 import org.zstack.header.core.Completion;
+import org.zstack.header.core.FutureCompletion;
 import org.zstack.header.core.NoErrorCompletion;
 import org.zstack.header.core.ReturnValueCompletion;
 import org.zstack.header.core.workflow.Flow;
@@ -50,6 +52,8 @@ import org.zstack.utils.function.Function;
 import org.zstack.utils.gson.JSONObjectUtil;
 import org.zstack.utils.logging.CLogger;
 
+import static org.zstack.core.Platform.createComponentLoaderFromWebApplicationContext;
+import static org.zstack.core.Platform.err;
 import static org.zstack.core.Platform.operr;
 
 import javax.persistence.Query;
@@ -107,49 +111,48 @@ public class NfsPrimaryStorageKVMBackend implements NfsPrimaryStorageBackend,
 
     private static final String QCOW3_QEMU_IMG_VERSION = "2.0.0";
 
-    private void mount(PrimaryStorageInventory inv, String hostUuid) {
+    private void mount(PrimaryStorageInventory inv, String hostUuid, Completion completion) {
         MountCmd cmd = new MountCmd();
         cmd.setUrl(inv.getUrl());
         cmd.setMountPath(inv.getMountPath());
         cmd.setUuid(inv.getUuid());
         cmd.setOptions(NfsSystemTags.MOUNT_OPTIONS.getTokenByResourceUuid(inv.getUuid(), NfsSystemTags.MOUNT_OPTIONS_TOKEN));
 
-        KVMHostSyncHttpCallMsg msg = new KVMHostSyncHttpCallMsg();
-        msg.setCommand(cmd);
-        msg.setPath(MOUNT_PRIMARY_STORAGE_PATH);
-        msg.setHostUuid(hostUuid);
-        msg.setNoStatusCheck(true);
-        bus.makeTargetServiceIdByResourceUuid(msg, HostConstant.SERVICE_ID, hostUuid);
-        MessageReply reply = bus.call(msg);
+        KvmCommandSender sender = new KvmCommandSender(hostUuid);
+        sender.send(cmd, MOUNT_PRIMARY_STORAGE_PATH, new KvmCommandFailureChecker() {
+            @Override
+            public ErrorCode getError(KvmResponseWrapper wrapper) {
+                MountAgentResponse rsp = wrapper.getResponse(MountAgentResponse.class);
+                return rsp.isSuccess() ? null : operr(rsp.getError());
+            }
+        }, new ReturnValueCompletion<KvmResponseWrapper>(completion) {
+            @Override
+            public void success(KvmResponseWrapper returnValue) {
+                MountAgentResponse rsp = returnValue.getResponse(MountAgentResponse.class);
+                new PrimaryStorageCapacityUpdater(inv.getUuid()).update(
+                        rsp.getTotalCapacity(), rsp.getAvailableCapacity(), rsp.getTotalCapacity(), rsp.getAvailableCapacity()
+                );
 
-        if (!reply.isSuccess()) {
-            ErrorCode err = reply.getError();
-
-            if (reply.getError().getDetails().contains("java.net.SocketTimeoutException: Read timed out")) {
-                // socket read timeout is caused by timeout of mounting a wrong URL
-                err = errf.instantiateErrorCode(SysErrors.TIMEOUT, String.format("mount timeout. Please the check if the URL[%s] is" +
-                        " valid to mount", inv.getUrl()), reply.getError());
+                logger.debug(String.format(
+                        "Successfully mounted nfs primary storage[uuid:%s] on kvm host[uuid:%s]",
+                        inv.getUuid(), hostUuid));
+                completion.success();
             }
 
-            throw new OperationFailureException(err);
-        }
-
-        MountAgentResponse rsp = ((KVMHostSyncHttpCallReply) reply).toResponse(MountAgentResponse.class);
-        if (!rsp.isSuccess()) {
-            throw new OperationFailureException(operr(rsp.getError()));
-        }
-
-        new PrimaryStorageCapacityUpdater(inv.getUuid()).update(
-                rsp.getTotalCapacity(), rsp.getAvailableCapacity(), rsp.getTotalCapacity(), rsp.getAvailableCapacity()
-        );
-
-        logger.debug(String.format(
-                "Successfully mounted nfs primary storage[uuid:%s] on kvm host[uuid:%s]",
-                inv.getUuid(), hostUuid));
+            @Override
+            public void fail(ErrorCode errorCode) {
+                if (errorCode.getDetails().contains("java.net.SocketTimeoutException: Read timed out")) {
+                    // socket read timeout is caused by timeout of mounting a wrong URL
+                    errorCode = errf.instantiateErrorCode(SysErrors.TIMEOUT, String.format("mount timeout. Please the check if the URL[%s] is" +
+                            " valid to mount", inv.getUrl()), errorCode);
+                }
+                completion.fail(errorCode);
+            }
+        });
     }
 
     @Override
-    public boolean attachToCluster(PrimaryStorageInventory inv, String clusterUuid) throws NfsPrimaryStorageException {
+    public void attachToCluster(PrimaryStorageInventory inv, String clusterUuid, ReturnValueCompletion<Boolean> completion){
         if (!CoreGlobalProperty.UNIT_TEST_ON) {
             checkQemuImgVersionInOtherClusters(inv, clusterUuid);
         }
@@ -160,11 +163,37 @@ public class NfsPrimaryStorageKVMBackend implements NfsPrimaryStorageBackend,
         query.add(HostVO_.status, Op.EQ, HostStatus.Connected);
         query.add(HostVO_.clusterUuid, Op.EQ, clusterUuid);
         List<String> hostUuids = query.listValue();
-        for (String huuid : hostUuids) {
-            mount(inv, huuid);
+        if(hostUuids.isEmpty()){
+            completion.success(false);// !isEmpty
+            return;
         }
 
-        return !hostUuids.isEmpty();
+        List<ErrorCode> errs = new ArrayList<>();
+        new While<>(hostUuids).all((hostUuid, compl) -> {
+            mount(inv, hostUuid, new Completion(compl){
+
+                @Override
+                public void success() {
+                    compl.done();
+                }
+
+                @Override
+                public void fail(ErrorCode errorCode) {
+                    errs.add(errorCode);
+                    compl.done();
+                }
+            });
+
+        }).run(new NoErrorCompletion() {
+            @Override
+            public void done() {
+                if(!errs.isEmpty()){
+                    completion.fail(errs.get(0));
+                }else {
+                    completion.success(true);
+                }
+            }
+        });
     }
 
     private void checkQemuImgVersionInOtherClusters(final PrimaryStorageInventory inv, String clusterUuid) {
@@ -638,9 +667,39 @@ public class NfsPrimaryStorageKVMBackend implements NfsPrimaryStorageBackend,
         if (ps.isEmpty()) {
             return;
         }
+        FutureCompletion compl = new FutureCompletion(null);
 
-        for (PrimaryStorageVO pvo : ps) {
-            mount(PrimaryStorageInventory.valueOf(pvo), inv.getUuid());
+        List<ErrorCode> errs = new ArrayList<>();
+        new While<>(ps).each((pvo, completion) -> {
+            mount(PrimaryStorageInventory.valueOf(pvo), inv.getUuid(), new Completion(completion){
+
+                @Override
+                public void success() {
+                    completion.done();
+                }
+
+                @Override
+                public void fail(ErrorCode errorCode) {
+                    errs.add(errorCode);
+                    completion.done();
+                }
+            });
+
+        }).run(new NoErrorCompletion() {
+            @Override
+            public void done() {
+                if(!errs.isEmpty()){
+                    compl.fail(errs.get(0));
+                }else {
+                    compl.success();
+                }
+            }
+        });
+
+        compl.await();
+
+        if (!compl.isSuccess()) {
+            throw new OperationFailureException(compl.getErrorCode());
         }
     }
 
@@ -1015,9 +1074,17 @@ public class NfsPrimaryStorageKVMBackend implements NfsPrimaryStorageBackend,
 
                             @Override
                             public void fail(ErrorCode errorCode) {
+                                errors.add(errorCode);
                                 logger.warn(String.format("failed to update the nfs[uuid:%s, name:%s] mount point" +
-                                                " from %s to %s in the cluster[uuid:%s], %s", pinv.getUuid(), pinv.getName(),
-                                        oldMountPoint, newMountPoint, hostUuid, errorCode));
+                                                " from %s to %s in the cluster[uuid:%s], Disconnected this host, %s",
+                                        pinv.getUuid(), pinv.getName(), oldMountPoint, newMountPoint, hostUuid, errorCode));
+
+                                //TODO: need notification to UI
+                                ChangeHostConnectionStateMsg cmsg = new ChangeHostConnectionStateMsg();
+                                cmsg.setConnectionStateEvent(HostStatusEvent.disconnected.toString());
+                                cmsg.setHostUuid(hostUuid);
+                                bus.makeTargetServiceIdByResourceUuid(cmsg, HostConstant.SERVICE_ID, hostUuid);
+                                bus.send(cmsg);// disconnected host will always return success
                                 completion.done();
                             }
                         });
@@ -1027,7 +1094,11 @@ public class NfsPrimaryStorageKVMBackend implements NfsPrimaryStorageBackend,
 
             @Override
             protected void done() {
-                completion.success();
+                if(errors.size() == huuids.size()){
+                    completion.fail(errors.get(0));
+                }else {
+                    completion.success();
+                }
             }
         }.start();
     }

--- a/test/src/test/groovy/org/zstack/test/integration/storage/primary/nfs/InvalidUrlCase.groovy
+++ b/test/src/test/groovy/org/zstack/test/integration/storage/primary/nfs/InvalidUrlCase.groovy
@@ -1,0 +1,275 @@
+package org.zstack.test.integration.storage.primary.nfs
+
+import org.springframework.http.HttpEntity
+import org.zstack.core.db.Q
+import org.zstack.header.Constants
+import org.zstack.header.agent.AgentResponse
+import org.zstack.header.host.Host
+import org.zstack.header.host.HostStatus
+import org.zstack.header.host.HostVO
+import org.zstack.header.host.HostVO_
+import org.zstack.header.storage.primary.PrimaryStorageVO
+import org.zstack.header.storage.primary.PrimaryStorageVO_
+import org.zstack.sdk.AttachPrimaryStorageToClusterAction
+import org.zstack.sdk.HostInventory
+import org.zstack.sdk.PrimaryStorageInventory
+import org.zstack.sdk.ClusterInventory
+import org.zstack.sdk.ReconnectBackupStorageAction
+import org.zstack.sdk.ReconnectHostAction
+import org.zstack.sdk.ReconnectPrimaryStorageAction
+import org.zstack.sdk.UpdatePrimaryStorageAction
+import org.zstack.storage.primary.nfs.NfsPrimaryStorageKVMBackend
+import org.zstack.storage.primary.nfs.NfsPrimaryStorageKVMBackendCommands
+import org.zstack.test.integration.storage.Env
+import org.zstack.test.integration.storage.StorageTest
+import org.zstack.testlib.EnvSpec
+import org.zstack.testlib.HttpError
+import org.zstack.testlib.NfsPrimaryStorageSpec
+import org.zstack.testlib.SubCase
+import org.zstack.utils.gson.JSONObjectUtil
+
+/**
+ * Created by MaJin on 2017-04-24.
+ */
+class InvalidUrlCase extends SubCase {
+    EnvSpec env
+    ClusterInventory cluInv
+    PrimaryStorageInventory psInv
+    HostInventory host
+    HostInventory host1
+
+    @Override
+    void setup() {
+        useSpring(StorageTest.springSpec)
+    }
+
+    @Override
+    void environment() {
+        env = Env.nfsOneVmEnv()
+    }
+
+    @Override
+    void test() {
+        env.create {
+            cluInv = env.inventoryByName("cluster") as ClusterInventory
+            psInv = env.inventoryByName("nfs") as PrimaryStorageInventory
+            host = env.inventoryByName("kvm") as HostInventory
+            host1 = env.inventoryByName("kvm1") as HostInventory
+            testDetachNfsFromCluster()
+            testAttachNfsToClusterWithInvalidUrl()
+            testAttachNfsToCluster()
+            testDetachNfsFromCluster()
+            testAttachNfsToClusterWithInvalidUrl()
+            testAttachNfsToCluster()
+            testUpdateValidUrl()
+            testUpdateUrlNotAllHostReturnFailure();
+            testReconnectHostWithInvalidNfsUrl();
+            testReconnectHost();
+            testUpdateValidUrl();
+            testUpdateInvalidUrl()
+            testReconnectHostWithInvalidNfsUrl()
+            testReconnectHost()
+            testReconnectNfsWithInvalidUrl()
+            testReconnectHost()
+            testReconnectNfs()
+        }
+    }
+
+    @Override
+    void clean() {
+        env.delete()
+    }
+    void testDetachNfsFromCluster() {
+        detachPrimaryStorageFromCluster {
+            primaryStorageUuid = psInv.uuid
+            clusterUuid = cluInv.uuid
+            sessionId = currentEnvSpec.session.uuid
+        }
+    }
+
+    void testAttachNfsToCluster(){
+        env.simulator(NfsPrimaryStorageKVMBackend.MOUNT_PRIMARY_STORAGE_PATH) { HttpEntity<String> e, EnvSpec espec ->
+            def cmd = JSONObjectUtil.toObject(e.getBody(), NfsPrimaryStorageKVMBackendCommands.MountCmd.class)
+            NfsPrimaryStorageSpec spec = espec.specByUuid(cmd.uuid) as NfsPrimaryStorageSpec
+            def rsp = new NfsPrimaryStorageKVMBackendCommands.MountAgentResponse()
+            rsp.totalCapacity = spec.totalCapacity
+            rsp.availableCapacity = spec.availableCapacity
+            return rsp
+        }
+
+        attachPrimaryStorageToCluster {
+            primaryStorageUuid = psInv.uuid
+            clusterUuid = cluInv.uuid
+            sessionId = currentEnvSpec.session.uuid
+        }
+
+
+
+    }
+
+    void testAttachNfsToClusterWithInvalidUrl() {
+        env.simulator(NfsPrimaryStorageKVMBackend.MOUNT_PRIMARY_STORAGE_PATH){
+            AgentResponse rsp = new AgentResponse()
+            rsp.setError("No such file")
+            rsp.setSuccess(false)
+            return rsp
+        }
+
+        AttachPrimaryStorageToClusterAction a = new AttachPrimaryStorageToClusterAction()
+        a.clusterUuid = cluInv.uuid
+        a.primaryStorageUuid = psInv.uuid
+        a.sessionId = currentEnvSpec.session.uuid
+
+        assert a.call().error != null
+
+    }
+
+    void testUpdateInvalidUrl(){
+        env.simulator(NfsPrimaryStorageKVMBackend.UPDATE_MOUNT_POINT_PATH){
+            AgentResponse rsp = new AgentResponse()
+            rsp.setError("No such file")
+            rsp.setSuccess(false)
+            return rsp
+        }
+
+        updatePrimaryStorage {
+            uuid = psInv.uuid
+            url = psInv.url
+            sessionId = currentEnvSpec.session.uuid
+        }
+
+        UpdatePrimaryStorageAction a = new UpdatePrimaryStorageAction()
+        a.uuid = psInv.uuid
+        a.url = "172.20.11.11:/wrong/directory"
+        a.sessionId = currentEnvSpec.session.uuid;
+
+        assert a.call().error != null
+
+        assert Q.New(PrimaryStorageVO.class)
+                .select(PrimaryStorageVO_.url)
+                .eq(PrimaryStorageVO_.uuid, psInv.uuid)
+                .findValue() == psInv.url
+
+    }
+
+    void testUpdateValidUrl(){
+        env.simulator(NfsPrimaryStorageKVMBackend.UPDATE_MOUNT_POINT_PATH) { HttpEntity<String> e, EnvSpec espec ->
+            def cmd = JSONObjectUtil.toObject(e.getBody(), NfsPrimaryStorageKVMBackendCommands.UpdateMountPointCmd.class)
+            NfsPrimaryStorageSpec spec = espec.specByUuid(cmd.uuid) as NfsPrimaryStorageSpec
+            def rsp = new NfsPrimaryStorageKVMBackendCommands.UpdateMountPointRsp()
+            rsp.totalCapacity = spec.totalCapacity
+            rsp.availableCapacity = spec.availableCapacity
+            return rsp
+        }
+        updatePrimaryStorage {
+            uuid = psInv.uuid
+            url = "172.20.11.11:/true/directory"
+            sessionId = currentEnvSpec.session.uuid
+        }
+        updatePrimaryStorage {
+            uuid = psInv.uuid
+            url = psInv.url
+            sessionId = currentEnvSpec.session.uuid
+        }
+    }
+
+    void testUpdateUrlNotAllHostReturnFailure(){
+        env.simulator(NfsPrimaryStorageKVMBackend.UPDATE_MOUNT_POINT_PATH) { HttpEntity<String> e, EnvSpec espec ->
+            def cmd = JSONObjectUtil.toObject(e.getBody(), NfsPrimaryStorageKVMBackendCommands.UpdateMountPointCmd.class)
+            def huuid = e.getHeaders().getFirst(Constants.AGENT_HTTP_HEADER_RESOURCE_UUID)
+            if( huuid == host.uuid){
+                AgentResponse rsp = new AgentResponse()
+                rsp.setError("Connection error")
+                rsp.setSuccess(false)
+                return rsp
+            }else {
+                NfsPrimaryStorageSpec spec = espec.specByUuid(cmd.uuid) as NfsPrimaryStorageSpec
+                def rsp = new NfsPrimaryStorageKVMBackendCommands.UpdateMountPointRsp()
+                rsp.totalCapacity = spec.totalCapacity
+                rsp.availableCapacity = spec.availableCapacity
+                return rsp
+            }
+        }
+
+        updatePrimaryStorage {
+            uuid = psInv.uuid
+            url = "172.20.11.11:/true/directory"
+            sessionId = currentEnvSpec.session.uuid
+        }
+
+        retryInSecs(){
+            List<HostInventory> hostInvs = queryHost {
+                conditions = ["status=${HostStatus.Disconnected}"]
+            }as List<HostInventory>
+
+            return {
+                assert hostInvs.size() == 1
+            }
+        }
+
+        assert Q.New(PrimaryStorageVO.class)
+                .eq(PrimaryStorageVO_.uuid, psInv.uuid)
+                .select(PrimaryStorageVO_.url).findValue() == "172.20.11.11:/true/directory"
+    }
+
+    void testReconnectHostWithInvalidNfsUrl(){
+        env.simulator(NfsPrimaryStorageKVMBackend.REMOUNT_PATH){
+            AgentResponse rsp = new AgentResponse()
+            rsp.setError("No such file")
+            rsp.setSuccess(false)
+            return rsp
+        }
+        ReconnectHostAction a = new ReconnectHostAction()
+        a.uuid = host.uuid
+        a.sessionId = currentEnvSpec.session.uuid
+
+        assert a.call().error != null
+    }
+
+    void testReconnectHost(){
+        env.simulator(NfsPrimaryStorageKVMBackend.REMOUNT_PATH) { HttpEntity<String> e, EnvSpec espec ->
+            def cmd = JSONObjectUtil.toObject(e.getBody(), NfsPrimaryStorageKVMBackendCommands.RemountCmd.class)
+            NfsPrimaryStorageSpec spec = espec.specByUuid(cmd.uuid) as NfsPrimaryStorageSpec
+            def rsp = new NfsPrimaryStorageKVMBackendCommands.NfsPrimaryStorageAgentResponse()
+            rsp.totalCapacity = spec.totalCapacity
+            rsp.availableCapacity = spec.availableCapacity
+            return rsp
+        }
+
+        reconnectHost {
+            uuid = host.uuid
+            sessionId = currentEnvSpec.session.uuid
+        }
+    }
+
+    void testReconnectNfs(){
+        env.simulator(NfsPrimaryStorageKVMBackend.REMOUNT_PATH) { HttpEntity<String> e, EnvSpec espec ->
+            def cmd = JSONObjectUtil.toObject(e.getBody(), NfsPrimaryStorageKVMBackendCommands.RemountCmd.class)
+            NfsPrimaryStorageSpec spec = espec.specByUuid(cmd.uuid) as NfsPrimaryStorageSpec
+            def rsp = new NfsPrimaryStorageKVMBackendCommands.NfsPrimaryStorageAgentResponse()
+            rsp.totalCapacity = spec.totalCapacity
+            rsp.availableCapacity = spec.availableCapacity
+            return rsp
+        }
+
+        reconnectPrimaryStorage {
+            uuid = psInv.uuid
+            sessionId = currentEnvSpec.session.uuid
+        }
+    }
+
+    void testReconnectNfsWithInvalidUrl(){
+        env.simulator(NfsPrimaryStorageKVMBackend.REMOUNT_PATH){
+            AgentResponse rsp = new AgentResponse()
+            rsp.setError("No such file")
+            rsp.setSuccess(false)
+            return rsp
+        }
+
+        ReconnectPrimaryStorageAction a = new ReconnectPrimaryStorageAction()
+        a.uuid = psInv.uuid
+        a.sessionId = currentEnvSpec.session.uuid
+
+        assert a.call().error != null
+    }
+}


### PR DESCRIPTION
there are four places I modify:

1.  if update url  fail, APIupdate will fail,
 agent will filter exception except "No such file" and "timed out" when mount nfs
2.  when attach nfs, modify sync mount to async mount
3.  move checkurl and checkVm to API validate
4.  add timeout when agent mount nfs, timeout is 180s

BAT pass

BTW, because i modify the mount function to async, it will Influence a msg(ChangeHostConnectionStateMsg) which is not used now.
I still fix it in another way.

 for https://github.com/zstackio/issues/issues/2756