### PR TITLE
don't check table "DataVolumeUsageVO", "RootVolumeUsageVO", "VmUsageVO"

### DIFF
--- a/testlib/src/main/java/org/zstack/testlib/EnvSpec.groovy
+++ b/testlib/src/main/java/org/zstack/testlib/EnvSpec.groovy
@@ -510,7 +510,8 @@ class EnvSpec implements Node {
                               "AccountVO", "NetworkServiceProviderVO",
                               "NetworkServiceTypeVO", "VmInstanceSequenceNumberVO",
                               "GarbageCollectorVO", "SystemTagVO", "AccountResourceRefVO",
-                              "TaskProgressVO", "NotificationVO", "TaskStepVO"]) {
+                              "TaskProgressVO", "NotificationVO", "TaskStepVO",
+                              "DataVolumeUsageVO", "RootVolumeUsageVO", "VmUsageVO"]) {
                 //TODO: fix SystemTagVO, AccountResourceRefVO
                 // those tables will continue having entries during running a test suite
                 return


### PR DESCRIPTION
because the async may make cases unstable