### PR TITLE
fix bug 2329

### DIFF
--- a/compute/src/main/java/org/zstack/compute/allocator/HostCapacityReserveManagerImpl.java
+++ b/compute/src/main/java/org/zstack/compute/allocator/HostCapacityReserveManagerImpl.java
@@ -292,7 +292,7 @@ public class HostCapacityReserveManagerImpl implements HostCapacityReserveManage
         List<HostVO> ret = new ArrayList<>(candidates.size());
         for (HostVO hvo : candidates) {
             ReservedHostCapacity hc = reserves.get(hvo.getUuid());
-            if (hvo.getCapacity().getAvailableMemory() - hc.getReservedMemoryCapacity() > ratioMgr.calculateMemoryByRatio(hvo.getUuid(), requiredMemory)) {
+            if (hvo.getCapacity().getAvailableMemory() - hc.getReservedMemoryCapacity() >= ratioMgr.calculateMemoryByRatio(hvo.getUuid(), requiredMemory)) {
                 ret.add(hvo);
             } else {
                 if (logger.isTraceEnabled()) {

--- a/test/src/test/groovy/org/zstack/test/integration/kvm/globalconfig/BatchCreateVmWhenSetReservedMemoryCase.groovy
+++ b/test/src/test/groovy/org/zstack/test/integration/kvm/globalconfig/BatchCreateVmWhenSetReservedMemoryCase.groovy
@@ -1,0 +1,180 @@
+package org.zstack.test.integration.kvm.globalconfig
+
+import org.zstack.network.securitygroup.SecurityGroupConstant
+import org.zstack.sdk.GetCpuMemoryCapacityAction
+import org.zstack.test.integration.kvm.hostallocator.AllocatorTest
+import org.zstack.testlib.*
+import org.zstack.utils.data.SizeUnit
+
+/**
+ * Created by camile on 2017/4.
+ */
+class BatchCreateVmWhenSetReservedMemoryCase extends SubCase {
+    EnvSpec env
+
+    @Override
+    void clean() {
+        env.delete()
+    }
+
+    @Override
+    void setup() {
+        useSpring(AllocatorTest.springSpec)
+    }
+
+    @Override
+    void environment() {
+        env = env {
+            instanceOffering {
+                name = "instanceOffering"
+                memory = SizeUnit.GIGABYTE.toByte(1)
+                cpu = 1
+            }
+
+            sftpBackupStorage {
+                name = "sftp"
+                url = "/sftp"
+                username = "root"
+                password = "password"
+                hostname = "localhost"
+
+                image {
+                    name = "image1"
+                    url = "http://zstack.org/download/test.qcow2"
+                }
+            }
+
+            zone {
+                name = "zone"
+                description = "test"
+
+                cluster {
+                    name = "cluster"
+                    hypervisorType = "KVM"
+
+                    kvm {
+                        name = "kvm1"
+                        managementIp = "127.0.0.2"
+                        username = "root"
+                        password = "password"
+
+                        totalCpu = 8
+                        totalMem = SizeUnit.GIGABYTE.toByte(10)
+                    }
+
+                    attachPrimaryStorage("local")
+                    attachL2Network("l2")
+                }
+
+                localPrimaryStorage {
+                    name = "local"
+                    url = "/local_ps"
+                }
+
+                l2NoVlanNetwork {
+                    name = "l2"
+                    physicalInterface = "eth0"
+
+                    l3Network {
+                        name = "l3"
+
+                        service {
+                            provider = SecurityGroupConstant.SECURITY_GROUP_PROVIDER_TYPE
+                            types = [SecurityGroupConstant.SECURITY_GROUP_NETWORK_SERVICE_TYPE]
+                        }
+
+                        ip {
+                            startIp = "192.168.100.10"
+                            endIp = "192.168.100.100"
+                            netmask = "255.255.255.0"
+                            gateway = "192.168.100.1"
+                        }
+                    }
+
+                    l3Network {
+                        name = "pubL3"
+
+                        ip {
+                            startIp = "12.16.10.10"
+                            endIp = "12.16.10.100"
+                            netmask = "255.255.255.0"
+                            gateway = "12.16.10.1"
+                        }
+                    }
+                }
+
+                attachBackupStorage("sftp")
+            }
+        }
+    }
+
+    @Override
+    void test() {
+        env.create {
+            testOrderCreateVms(9)
+            testConcurrentCreateVMs(10)
+        }
+    }
+    void testOrderCreateVms(Long num){
+        def thisImageUuid = (env.specByName("image1") as ImageSpec).inventory.uuid
+        def _1CPU1G = (env.specByName("instanceOffering") as InstanceOfferingSpec).inventory.uuid
+        def l3uuid = (env.specByName("pubL3") as L3NetworkSpec).inventory.uuid
+
+        for(int i=0;i++;i<num){
+            createVmInstance {
+                def vmName = "VM"+i
+                name = vmName
+                instanceOfferingUuid = _1CPU1G
+                imageUuid = thisImageUuid
+                l3NetworkUuids = [l3uuid]
+            }
+        }
+        expect(AssertionError.class) {
+            createVmInstance {
+                name = "VMM"
+                instanceOfferingUuid = _1CPU1G
+                imageUuid = thisImageUuid
+                l3NetworkUuids = [l3uuid]
+            }
+        }
+    }
+
+    void testConcurrentCreateVMs(Long num) {
+        def thisImageUuid = (env.specByName("image1") as ImageSpec).inventory.uuid
+        def _1CPU1G = (env.specByName("instanceOffering") as InstanceOfferingSpec).inventory.uuid
+        def l3uuid = (env.specByName("pubL3") as L3NetworkSpec).inventory.uuid
+
+        def threads = []
+        1.upto(num, {
+            def vmName = "VM-${it}".toString()
+            def thread = Thread.start {
+                createVmInstance {
+                    name = vmName
+                    instanceOfferingUuid = _1CPU1G
+                    imageUuid = thisImageUuid
+                    l3NetworkUuids = [l3uuid]
+                }
+            }
+
+            threads.add(thread)
+        })
+
+        threads.each { it.join() }
+
+        GetCpuMemoryCapacityAction getCpuMemoryCapacityAction = new GetCpuMemoryCapacityAction()
+        getCpuMemoryCapacityAction.all = true
+        getCpuMemoryCapacityAction.sessionId = adminSession()
+        GetCpuMemoryCapacityAction.Result res = getCpuMemoryCapacityAction.call()
+        assert res.error == null
+        assert res.value.availableMemory != SizeUnit.GIGABYTE.toByte(0)
+
+        expect(AssertionError.class) {
+            createVmInstance {
+                name = "VMM"
+                instanceOfferingUuid = _1CPU1G
+                imageUuid = thisImageUuid
+                l3NetworkUuids = [l3uuid]
+            }
+        }
+    }
+}


### PR DESCRIPTION
for https://github.com/zstackio/issues/issues/2329

该bug是个典型的并发问题。推断是由于并发中各个副本不可见而导致的脏读问题，解决方案是在`updater.run()`方法中添加了计算物理机保留内存的逻辑——该方法中带了锁。

已添加Case：顺序创建与并发创建，并考虑了CPU超分的情况。