### PR TITLE
fix bug apiParamValidation

### DIFF
--- a/portal/src/main/java/org/zstack/portal/apimediator/ApiMessageProcessorImpl.java
+++ b/portal/src/main/java/org/zstack/portal/apimediator/ApiMessageProcessorImpl.java
@@ -290,6 +290,10 @@ public class ApiMessageProcessorImpl implements ApiMessageProcessor {
                     throw new ApiMessageInterceptionException(argerr("field[%s] of message[%s] is mandatory, can not be null", f.getName(), msg.getClass().getName()));
                 }
 
+                if (at.required() && value != null && (value instanceof String) && "".equals(value)) {
+                    throw new ApiMessageInterceptionException(argerr("field[%s] of message[%s] is mandatory, can not be empty string", f.getName(), msg.getClass().getName()));
+                }
+
                 if (value != null && at.validValues().length > 0) {
                     List vals = Arrays.asList(at.validValues());
 

--- a/portal/src/main/java/org/zstack/portal/apimediator/ApiMessageProcessorImpl.java
+++ b/portal/src/main/java/org/zstack/portal/apimediator/ApiMessageProcessorImpl.java
@@ -290,8 +290,17 @@ public class ApiMessageProcessorImpl implements ApiMessageProcessor {
                     throw new ApiMessageInterceptionException(argerr("field[%s] of message[%s] is mandatory, can not be null", f.getName(), msg.getClass().getName()));
                 }
 
-                if (at.required() && value != null && (value instanceof String) && "".equals(value)) {
-                    throw new ApiMessageInterceptionException(argerr("field[%s] of message[%s] is mandatory, can not be empty string", f.getName(), msg.getClass().getName()));
+                if (at.required() && value != null) {
+                    if((value instanceof String) && StringUtils.isEmpty((String) value)){
+                        throw new ApiMessageInterceptionException(argerr("field[%s] of message[%s] is mandatory, can not be an empty string", f.getName(), msg.getClass().getName()));
+                    }else if (value instanceof Collection) {
+                        for (Object v : (Collection)value) {
+                            if (v instanceof String && StringUtils.isEmpty((String)v)) {
+                                throw new ApiMessageInterceptionException(argerr("field[%s] cannot contain any empty string", f.getName()));
+                            }
+                        }
+                    }
+
                 }
 
                 if (value != null && at.validValues().length > 0) {

--- a/test/src/test/groovy/org/zstack/test/integration/core/api/apiparam/APIParamRequiredCase.groovy
+++ b/test/src/test/groovy/org/zstack/test/integration/core/api/apiparam/APIParamRequiredCase.groovy
@@ -1,0 +1,54 @@
+package org.zstack.test.integration.core.api.apiparam
+
+import org.zstack.sdk.*
+import org.zstack.test.integration.kvm.Env
+import org.zstack.test.integration.kvm.KvmTest
+import org.zstack.testlib.EnvSpec
+import org.zstack.testlib.SubCase
+import org.zstack.testlib.Test
+
+/**
+ * Created by lining on 2017/05/01.
+ */
+class APIParamRequiredCase extends SubCase {
+    EnvSpec env
+
+    @Override
+    void setup() {
+        useSpring(KvmTest.springSpec)
+    }
+
+    @Override
+    void environment() {
+        env = Env.oneVmBasicEnv()
+    }
+
+    @Override
+    void test() {
+        env.create {
+            createVmWithEmptyNameTest()
+        }
+    }
+
+    void createVmWithEmptyNameTest() {
+        VmInstanceInventory vm = env.inventoryByName("vm")
+        assert null != vm
+
+        CreateVmInstanceAction createVmInstanceAction = new CreateVmInstanceAction(
+                name : "",
+                sessionId: Test.currentEnvSpec.session.uuid,
+                instanceOfferingUuid : vm.instanceOfferingUuid,
+                l3NetworkUuids : [vm.defaultL3NetworkUuid],
+                imageUuid : vm.imageUuid
+        )
+        CreateVmInstanceAction.Result result = createVmInstanceAction.call()
+        assert null != result.error
+        assert -1 < result.error.details.indexOf("empty string")
+
+    }
+
+    @Override
+    void clean() {
+        env.delete()
+    }
+}

--- a/test/src/test/groovy/org/zstack/test/integration/kvm/vm/CreateVmWithEmptyNameCase.groovy
+++ b/test/src/test/groovy/org/zstack/test/integration/kvm/vm/CreateVmWithEmptyNameCase.groovy
@@ -1,6 +1,7 @@
-package org.zstack.test.integration.core.api.apiparam
+package org.zstack.test.integration.kvm.vm
 
-import org.zstack.sdk.*
+import org.zstack.sdk.CreateVmInstanceAction
+import org.zstack.sdk.VmInstanceInventory
 import org.zstack.test.integration.kvm.Env
 import org.zstack.test.integration.kvm.KvmTest
 import org.zstack.testlib.EnvSpec
@@ -10,7 +11,7 @@ import org.zstack.testlib.Test
 /**
  * Created by lining on 2017/05/01.
  */
-class APIParamRequiredCase extends SubCase {
+class CreateVmWithEmptyNameCase extends SubCase {
     EnvSpec env
 
     @Override

--- a/test/src/test/groovy/org/zstack/test/integration/ldap/forcase/LdapConnCase.groovy
+++ b/test/src/test/groovy/org/zstack/test/integration/ldap/forcase/LdapConnCase.groovy
@@ -57,8 +57,8 @@ class LdapConnCase extends SubCase {
             description = "test-ldap0"
             base = LdapTest.DOMAIN_DSN
             url = "ldap://localhost:1888"
-            username = ""
-            password = ""
+            username = "notEmpty"
+            password = "passwd"
             encryption = "None"
             sessionId = currentEnvSpec.session.uuid
         } as LdapServerInventory


### PR DESCRIPTION
增强APIParam required=true语法检测，当value为String类型时，不允许出现empty string