### PR TITLE
annotation org.zstack.core.logging.Log#log

### DIFF
--- a/core/src/main/java/org/zstack/core/logging/Event.java
+++ b/core/src/main/java/org/zstack/core/logging/Event.java
@@ -47,6 +47,7 @@ public class Event extends Log {
 
     @ExceptionSafe
     public void log(String label, Object...args) {
-        setText(label, args).write();
+        // todo : move to notification
+        // setText(label, args).write();
     }
 }

--- a/core/src/main/java/org/zstack/core/logging/Log.java
+++ b/core/src/main/java/org/zstack/core/logging/Log.java
@@ -51,6 +51,70 @@ public class Log {
             this.date = other.date;
             this.opaque = other.opaque;
         }
+
+        public LogLevel getLevel() {
+            return level;
+        }
+
+        public void setLevel(LogLevel level) {
+            this.level = level;
+        }
+
+        public String getText() {
+            return text;
+        }
+
+        public void setText(String text) {
+            this.text = text;
+        }
+
+        public List getParameters() {
+            return parameters;
+        }
+
+        public void setParameters(List parameters) {
+            this.parameters = parameters;
+        }
+
+        public String getResourceUuid() {
+            return resourceUuid;
+        }
+
+        public void setResourceUuid(String resourceUuid) {
+            this.resourceUuid = resourceUuid;
+        }
+
+        public String getUuid() {
+            return uuid;
+        }
+
+        public void setUuid(String uuid) {
+            this.uuid = uuid;
+        }
+
+        public long getDateInLong() {
+            return dateInLong;
+        }
+
+        public void setDateInLong(long dateInLong) {
+            this.dateInLong = dateInLong;
+        }
+
+        public Date getDate() {
+            return date;
+        }
+
+        public void setDate(Date date) {
+            this.date = date;
+        }
+
+        public Object getOpaque() {
+            return opaque;
+        }
+
+        public void setOpaque(Object opaque) {
+            this.opaque = opaque;
+        }
     }
 
     protected Content content;
@@ -136,6 +200,8 @@ public class Log {
 
     @ExceptionSafe
     public void log(String label, Object...args) {
+        // todo : move to notification
+        /*
         for (int i=0; i<args.length; i++) {
             if (args[i] == null) {
                 args[i] = "null";
@@ -143,10 +209,13 @@ public class Log {
         }
 
         setText(label, args).write();
+        */
     }
 
     @ExceptionSafe
     public void log(String label, Collection args) {
+        // todo : move to notification
+        /*
         List noNullArgs = new ArrayList<>();
         args.forEach(i -> {
             if (i == null) {
@@ -156,6 +225,7 @@ public class Log {
             }
         });
         setText(label, noNullArgs).write();
+        */
     }
 
     public List getParameters() {


### PR DESCRIPTION
已修复，考虑到org.zstack.core.logging.Log已弃用，并且注释了产生错误日志的关键代码

ps: 产生错误信息如下：
2017-05-03 10:53:16,191 WARN  [CloudBusImpl2] {} error to restore the msg:
{"path":"/logging/event","content":{"message":"vm.strangers.found","level":"INFO","text":"vm.strangers.found","parameters":["2b46931d8fdf404c81c432912078e9e0","4964819ebdd04d3081e1404c54a086d3"],"resourceUuid":"36c27e8ff05c4780bf6d2fa65700f22e","uuid":"a7f58d772fab11e790226f403ffd5121","dateInLong":1493779996189,"date":"May 3, 2017 10:53:16 AM"},"managementNodeId":"48a9c15e83ea4f43b334eb7012b5d8ed","type":{"_name":"key.event.LOCAL.canonicalEvent"},"headers":{"schema":{"content":"org.zstack.core.logging.Event$EventContent","content.level":"org.zstack.core.logging.LogLevel"},"task-context":{"api":"52504c22db8e41b7b05197f2c78f3913","task-name":"org.zstack.header.image.APIAddImageMsg","progress-enabled":"true"}},"id":"21d7e4a0ca0b4667a93833f9b61b6c65","createdTime":1493779996189}
java.lang.RuntimeException: java.lang.NoSuchMethodException: Unknown property 'level' on class 'class org.zstack.core.logging.Event$EventContent'
        at org.zstack.utils.BeanUtils.getProperty(BeanUtils.java:190) ~[utils-1.10.0.jar:?]
        at org.zstack.core.cloudbus.CloudBusImpl2$Wire.restoreFromSchema(CloudBusImpl2.java:628) ~[core-1.10.0.jar:?]
        at org.zstack.core.cloudbus.CloudBusImpl2$Wire.toMessage(CloudBusImpl2.java:686) [core-1.10.0.jar:?]
        at org.zstack.core.cloudbus.CloudBusImpl2$EventMaid.handleDelivery(CloudBusImpl2.java:810) [core-1.10.0.jar:?]
        at com.rabbitmq.client.impl.ConsumerDispatcher$5.run(ConsumerDispatcher.java:140) [amqp-client-3.3.5.jar:?]
        at com.rabbitmq.client.impl.ConsumerWorkService$WorkPoolRunnable.run(ConsumerWorkService.java:85) [amqp-client-3.3.5.jar:?]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142) [?:1.8.0_102]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617) [?:1.8.0_102]
        at java.lang.Thread.run(Thread.java:745) [?:1.8.0_102]
Caused by: java.lang.NoSuchMethodException: Unknown property 'level' on class 'class org.zstack.core.logging.Event$EventContent'
        at org.apache.commons.beanutils.PropertyUtilsBean.getSimpleProperty(PropertyUtilsBean.java:1269) ~[commons-beanutils-1.9.3.jar:1.9.3]
        at org.apache.commons.beanutils.PropertyUtilsBean.getNestedProperty(PropertyUtilsBean.java:808) ~[commons-beanutils-1.9.3.jar:1.9.3]
        at org.apache.commons.beanutils.PropertyUtilsBean.getProperty(PropertyUtilsBean.java:884) ~[commons-beanutils-1.9.3.jar:1.9.3]
        at org.apache.commons.beanutils.PropertyUtils.getProperty(PropertyUtils.java:464) ~[commons-beanutils-1.9.3.jar:1.9.3]
        at org.zstack.utils.BeanUtils.getProperty(BeanUtils.java:176) ~[utils-1.10.0.jar:?]
