### PR TITLE
fix bug trigger EO cleanup

### DIFF
--- a/core/src/main/java/org/zstack/core/db/DatabaseFacadeImpl.java
+++ b/core/src/main/java/org/zstack/core/db/DatabaseFacadeImpl.java
@@ -723,7 +723,13 @@ public class DatabaseFacadeImpl implements DatabaseFacade, Component {
             return;
         }
 
-        info.hardDelete(ids);
+        try {
+            logger.info(String.format("clean EO[%s], to be cleaning data: %s", info.eoClass.getSimpleName(), ids.toString()));
+            info.hardDelete(ids);
+        }catch (Exception e){
+            // If has foreign key constraint, Allow cleanup failed
+            logger.info(String.format("clean EO[%s], an error has occurred, please ignore", info.eoClass.getSimpleName()));
+        }
     }
 
     @Override

--- a/portal/src/main/java/org/zstack/portal/apimediator/ApiMessageProcessorImpl.java
+++ b/portal/src/main/java/org/zstack/portal/apimediator/ApiMessageProcessorImpl.java
@@ -390,8 +390,12 @@ public class ApiMessageProcessorImpl implements ApiMessageProcessor {
                                     throw new CloudRuntimeException(String.format("the API class[%s] does not have @RestRequest but it uses a successIfResourceNotExisting helper", msg.getClass()));
                                 }
 
-                                // trigger EO cleanup
-                                dbf.eoCleanup(at.resourceType());
+                                try{
+                                    // trigger EO cleanup
+                                    dbf.eoCleanup(at.resourceType());
+                                }catch (Exception e){
+                                    //  If has foreign key constraint, Allow cleanup failed
+                                }
 
                                 APIEvent evt = (APIEvent) rat.responseClass().getConstructor(String.class).newInstance(msg.getId());
 

--- a/test/src/test/groovy/org/zstack/test/integration/image/DeleteImageCase.groovy
+++ b/test/src/test/groovy/org/zstack/test/integration/image/DeleteImageCase.groovy
@@ -1,0 +1,134 @@
+package org.zstack.test.integration.image
+
+import org.zstack.header.image.ImageEO
+import org.zstack.header.image.ImageStatus
+import org.zstack.header.image.ImageVO
+import org.zstack.sdk.ImageInventory
+import org.zstack.testlib.EnvSpec
+import org.zstack.testlib.SubCase
+import org.zstack.utils.data.SizeUnit
+
+/**
+ * Created by lining on 2017/5/5.
+ */
+class DeleteImageCase extends SubCase {
+    EnvSpec env
+
+    @Override
+    void setup() {
+        useSpring(ImageTest.springSpec)
+    }
+
+    @Override
+    void environment() {
+        env = env{
+            instanceOffering {
+                name = "instanceOffering"
+                memory = SizeUnit.GIGABYTE.toByte(8)
+                cpu = 4
+            }
+
+            sftpBackupStorage {
+                name = "sftp"
+                url = "/sftp"
+                username = "root"
+                password = "password"
+                hostname = "localhost"
+
+                image {
+                    name = "image"
+                    url = "http://zstack.org/download/test.qcow2"
+                }
+
+            }
+
+            zone {
+                name = "zone"
+                description = "test"
+
+                cluster {
+                    name = "cluster"
+                    hypervisorType = "KVM"
+
+                    kvm {
+                        name = "kvm"
+                        managementIp = "localhost"
+                        username = "root"
+                        password = "password"
+                    }
+
+                    attachPrimaryStorage("local")
+                    attachL2Network("l2")
+                }
+
+                localPrimaryStorage {
+                    name = "local"
+                    url = "/local_ps"
+                }
+
+                l2NoVlanNetwork {
+                    name = "l2"
+                    physicalInterface = "eth0"
+
+                    l3Network {
+                        name = "l3"
+
+                        ip {
+                            startIp = "192.168.100.10"
+                            endIp = "192.168.100.100"
+                            netmask = "255.255.255.0"
+                            gateway = "192.168.100.1"
+                        }
+                    }
+                }
+
+                attachBackupStorage("sftp")
+            }
+
+            vm {
+                name = "vm"
+                useInstanceOffering("instanceOffering")
+                useImage("image")
+                useL3Networks("l3")
+            }
+        }
+    }
+
+    @Override
+    void test() {
+        env.create {
+            runTest()
+        }
+    }
+
+    void runTest(){
+        ImageInventory image = env.inventoryByName("image")
+
+        deleteImage {
+            uuid = image.uuid
+        }
+        ImageVO imageVO = dbFindByUuid(image.uuid,ImageVO.class)
+        assert ImageStatus.Deleted == imageVO.status
+
+        expungeImage {
+            imageUuid = image.uuid
+        }
+        assert null == dbFindByUuid(image.uuid,ImageVO.class)
+        ImageEO imageEO = dbFindByUuid(image.uuid,ImageEO.class)
+        assert null != imageEO.deleted
+
+        deleteImage {
+            uuid = image.uuid
+        }
+        imageEO = dbFindByUuid(image.uuid,ImageEO.class)
+        // image used by vm, imageEO can't be cleaned
+        assert null != imageEO
+        assert null != imageEO.deleted
+
+    }
+
+    @Override
+    void clean() {
+        env.delete()
+    }
+}


### PR DESCRIPTION
背景：清除EO数据时，若存在外键关联，则不去清除EO数据

其他：
1.把清理EO操作放在了apiParamValidation里，个人认为会使代码可读性下降，给apiParamValidation分配了过多的职责
2.清理EO前，没有做可清理检查（外键检查），很可能清理的时候会报错，产生大量sql错误日志
3.清除EO的where语句为 deleted is not null，并不是只清理了APImessage里对应的uud，增加了清理失败的概率（外键关联），最后可能达不到清理EO的预期