### PR TITLE
Fix bug start vm when about l3 deleted

### DIFF
--- a/compute/src/main/java/org/zstack/compute/vm/VmInstanceBase.java
+++ b/compute/src/main/java/org/zstack/compute/vm/VmInstanceBase.java
@@ -79,6 +79,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.zstack.core.Platform.operr;
+import static org.zstack.core.Platform.err;
 import static org.zstack.utils.CollectionDSL.*;
 
 
@@ -3775,9 +3776,10 @@ public class VmInstanceBase extends AbstractVmInstance {
                 });
 
                 if(l3 == null){
-                    ErrorCode err = errf.instantiateErrorCode(SysErrors.RESOURCE_NOT_FOUND,
-                            String.format("Unable to find L3Network[uuid:%s] to start the current vm, it may have been deleted, Operation suggestion: delete this vm, recreate a new vm", l3Uuid));
-                    completion.fail(errf.instantiateErrorCode(SysErrors.OPERATION_ERROR, err));
+                    completion.fail(err(
+                            SysErrors.OPERATION_ERROR,
+                            "Unable to find L3Network[uuid:%s] to start the current vm, it may have been deleted, Operation suggestion: delete this vm, recreate a new vm",
+                            l3Uuid));
                     return;
                 }
                 DebugUtils.Assert(l3 != null, "where is the L3???");

--- a/compute/src/main/java/org/zstack/compute/vm/VmInstanceBase.java
+++ b/compute/src/main/java/org/zstack/compute/vm/VmInstanceBase.java
@@ -3773,6 +3773,13 @@ public class VmInstanceBase extends AbstractVmInstance {
                         return arg.getUuid().equals(l3Uuid) ? arg : null;
                     }
                 });
+
+                if(l3 == null){
+                    ErrorCode err = errf.instantiateErrorCode(SysErrors.RESOURCE_NOT_FOUND,
+                            String.format("Unable to find L3Network[uuid:%s] to start the current vm, it may have been deleted, Operation suggestion: delete this vm, recreate a new vm", l3Uuid));
+                    completion.fail(errf.instantiateErrorCode(SysErrors.OPERATION_ERROR, err));
+                    return;
+                }
                 DebugUtils.Assert(l3 != null, "where is the L3???");
                 l3s.add(l3);
             }

--- a/test/src/test/groovy/org/zstack/test/integration/kvm/vm/start/StartCreatedStatusVmWhenL3DeletedCase.groovy
+++ b/test/src/test/groovy/org/zstack/test/integration/kvm/vm/start/StartCreatedStatusVmWhenL3DeletedCase.groovy
@@ -1,0 +1,73 @@
+package org.zstack.test.integration.kvm.vm.start
+
+import org.zstack.header.vm.VmCreationStrategy
+import org.zstack.sdk.StartVmInstanceAction
+import org.zstack.sdk.VmInstanceInventory
+import org.zstack.test.integration.kvm.Env
+import org.zstack.test.integration.kvm.KvmTest
+import org.zstack.testlib.EnvSpec
+import org.zstack.testlib.SubCase
+import org.zstack.testlib.Test
+
+/**
+ * Created by lining on 2017/2/22.
+ */
+class StartCreatedStatusVmWhenL3DeletedCase extends SubCase {
+    EnvSpec env
+
+    @Override
+    void setup() {
+        useSpring(KvmTest.springSpec)
+    }
+
+    @Override
+    void environment() {
+        env = Env.oneVmBasicEnv()
+    }
+
+    @Override
+    void test() {
+        env.create {
+            runTest()
+        }
+    }
+
+    void runTest(){
+        VmInstanceInventory vm = env.inventoryByName("vm")
+
+        VmInstanceInventory newVm = createVmInstance {
+            name = "newVm"
+            imageUuid = vm.imageUuid
+            instanceOfferingUuid = vm.instanceOfferingUuid
+            l3NetworkUuids = [vm.defaultL3NetworkUuid]
+            strategy =  VmCreationStrategy.JustCreate.name()
+        }
+
+        deleteL3Network {
+            uuid = newVm.defaultL3NetworkUuid
+        }
+
+        StartVmInstanceAction startVmInstanceAction = new StartVmInstanceAction(
+                uuid: newVm.uuid,
+                sessionId: Test.currentEnvSpec.session.uuid
+        )
+        StartVmInstanceAction.Result result = startVmInstanceAction.call()
+        assert null != result.error
+        assert result.error.details.indexOf("Unable to find L3Network") > -1
+
+        // clean EO There is a bug, fix pr is ready,
+        // so need delete  vm
+
+        /*
+        destroyVmInstance {
+            uuid = newVm.uuid
+        }
+        */
+
+    }
+
+    @Override
+    void clean() {
+        env.delete()
+    }
+}

--- a/test/src/test/groovy/org/zstack/test/integration/kvm/vm/start/StartCreatedStatusVmWhenL3DeletedCase.groovy
+++ b/test/src/test/groovy/org/zstack/test/integration/kvm/vm/start/StartCreatedStatusVmWhenL3DeletedCase.groovy
@@ -54,13 +54,6 @@ class StartCreatedStatusVmWhenL3DeletedCase extends SubCase {
         StartVmInstanceAction.Result result = startVmInstanceAction.call()
         assert null != result.error
         assert result.error.details.indexOf("Unable to find L3Network") > -1
-
-        // clean EO There is a bug, fix pr is ready,
-        // so need delete  vm
-        destroyVmInstance {
-            uuid = newVm.uuid
-        }
-
     }
 
     @Override

--- a/test/src/test/groovy/org/zstack/test/integration/kvm/vm/start/StartCreatedStatusVmWhenL3DeletedCase.groovy
+++ b/test/src/test/groovy/org/zstack/test/integration/kvm/vm/start/StartCreatedStatusVmWhenL3DeletedCase.groovy
@@ -57,12 +57,9 @@ class StartCreatedStatusVmWhenL3DeletedCase extends SubCase {
 
         // clean EO There is a bug, fix pr is ready,
         // so need delete  vm
-
-        /*
         destroyVmInstance {
             uuid = newVm.uuid
         }
-        */
 
     }
 


### PR DESCRIPTION
背景：创建一个created vm, 删除此vm使用的L3后， 不允许用户再启动vm