### PR TITLE
Implement vtep cascade delete

### DIFF
--- a/conf/springConfigXml/vxlan.xml
+++ b/conf/springConfigXml/vxlan.xml
@@ -78,4 +78,10 @@
         </zstack:plugin>
     </bean>
 
+    <bean id="VtepCascadeExtension" class="org.zstack.network.l2.vxlan.vtep.VtepCascadeExtension">
+        <zstack:plugin>
+            <zstack:extension interface="org.zstack.core.cascade.CascadeExtensionPoint" />
+        </zstack:plugin>
+    </bean>
+
 </beans>

--- a/plugin/vxlan/src/main/java/org/zstack/network/l2/vxlan/vtep/DeleteVtepMsg.java
+++ b/plugin/vxlan/src/main/java/org/zstack/network/l2/vxlan/vtep/DeleteVtepMsg.java
@@ -1,0 +1,30 @@
+package org.zstack.network.l2.vxlan.vtep;
+
+import org.zstack.header.message.NeedReplyMessage;
+import org.zstack.header.network.l2.L2NetworkMessage;
+
+/**
+ * Created by weiwang on 12/05/2017.
+ */
+public class DeleteVtepMsg extends NeedReplyMessage implements L2NetworkMessage {
+    private String l2NetworkUuid;
+
+    private String vtepUuid;
+
+    @Override
+    public String getL2NetworkUuid() {
+        return l2NetworkUuid;
+    }
+
+    public void setL2NetworkUuid(String l2NetworkUuid) {
+        this.l2NetworkUuid = l2NetworkUuid;
+    }
+
+    public String getVtepUuid() {
+        return vtepUuid;
+    }
+
+    public void setVtepUuid(String vtepUuid) {
+        this.vtepUuid = vtepUuid;
+    }
+}

--- a/plugin/vxlan/src/main/java/org/zstack/network/l2/vxlan/vtep/DeleteVtepReply.java
+++ b/plugin/vxlan/src/main/java/org/zstack/network/l2/vxlan/vtep/DeleteVtepReply.java
@@ -1,0 +1,9 @@
+package org.zstack.network.l2.vxlan.vtep;
+
+import org.zstack.header.message.MessageReply;
+
+/**
+ * Created by weiwang on 12/05/2017.
+ */
+public class DeleteVtepReply extends MessageReply {
+}

--- a/plugin/vxlan/src/main/java/org/zstack/network/l2/vxlan/vtep/VtepCascadeExtension.java
+++ b/plugin/vxlan/src/main/java/org/zstack/network/l2/vxlan/vtep/VtepCascadeExtension.java
@@ -1,0 +1,158 @@
+package org.zstack.network.l2.vxlan.vtep;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.zstack.core.asyncbatch.While;
+import org.zstack.core.cascade.AbstractAsyncCascadeExtension;
+import org.zstack.core.cascade.CascadeAction;
+import org.zstack.core.cascade.CascadeConstant;
+import org.zstack.core.cloudbus.CloudBus;
+import org.zstack.core.cloudbus.CloudBusCallBack;
+import org.zstack.core.db.DatabaseFacade;
+import org.zstack.core.db.Q;
+import org.zstack.core.errorcode.ErrorFacade;
+import org.zstack.header.core.Completion;
+import org.zstack.header.core.NoErrorCompletion;
+import org.zstack.header.message.MessageReply;
+import org.zstack.header.network.l2.*;
+import org.zstack.utils.CollectionUtils;
+import org.zstack.utils.Utils;
+import org.zstack.utils.function.Function;
+import org.zstack.utils.logging.CLogger;
+
+import java.util.*;
+
+/**
+ * Created by weiwang on 12/05/2017.
+ */
+public class VtepCascadeExtension extends AbstractAsyncCascadeExtension {
+    private static final CLogger logger = Utils.getLogger(VtepCascadeExtension.class);
+
+    @Override
+    public void asyncCascade(CascadeAction action, Completion completion) {
+        if (action.isActionCode(CascadeConstant.DELETION_DELETE_CODE, CascadeConstant.DELETION_FORCE_DELETE_CODE)) {
+            handleDeletion(action, completion);
+        } else if (action.isActionCode(CascadeConstant.DELETION_CLEANUP_CODE)) {
+            handleDeletionCleanup(action, completion);
+        } else if (action.isActionCode(L2NetworkConstant.DETACH_L2NETWORK_CODE)) {
+            handleDetach(action, completion);
+        } else {
+            completion.success();
+        }
+    }
+
+    @Autowired
+    private DatabaseFacade dbf;
+    @Autowired
+    private CloudBus bus;
+    @Autowired
+    private ErrorFacade errf;
+
+    private static final String NAME = VtepVO.class.getSimpleName();
+
+    @Override
+    public List<String> getEdgeNames() {
+        return Arrays.asList(L2NetworkVO.class.getSimpleName());
+    }
+
+    @Override
+    public String getCascadeResourceName() {
+        return NAME;
+    }
+
+    private void handleDetach(CascadeAction action, final Completion completion) {
+        List<L2NetworkDetachStruct> structs = action.getParentIssuerContext();
+        List<VtepVO> vteps = new ArrayList<>();
+        for (L2NetworkDetachStruct s : structs) {
+            vteps.addAll(Q.New(VtepVO.class).eq(VtepVO_.poolUuid, s.getL2NetworkUuid()).eq(VtepVO_.clusterUuid, s.getClusterUuid()).list());
+        }
+
+        if (vteps.isEmpty()) {
+            completion.success();
+            return;
+        }
+
+        new While<>(vteps).all((vtep, completion1) -> {
+            DeleteVtepMsg msg = new DeleteVtepMsg();
+            msg.setL2NetworkUuid(vtep.getPoolUuid());
+            msg.setVtepUuid(vtep.getUuid());
+            bus.makeTargetServiceIdByResourceUuid(msg, L2NetworkConstant.SERVICE_ID, msg.getL2NetworkUuid());
+            bus.send(msg, new CloudBusCallBack(completion1) {
+                @Override
+                public void run(MessageReply reply) {
+                    if (!reply.isSuccess()) {
+                        logger.warn(reply.getError().toString());
+                    }
+                    completion1.done();
+                }
+            });
+        }).run(new NoErrorCompletion(completion) {
+            @Override
+            public void done() {
+                completion.success();
+            }
+        });
+    }
+
+    private void handleDeletionCleanup(CascadeAction action, Completion completion) {
+        dbf.eoCleanup(VtepVO.class);
+        completion.success();
+    }
+
+    private void handleDeletion(final CascadeAction action, final Completion completion) {
+        List<VtepInventory> vteps = vtepFromAction(action);
+
+        new While<>(vteps).all((vtep, completion1) -> {
+            DeleteVtepMsg msg = new DeleteVtepMsg();
+            msg.setL2NetworkUuid(vtep.getPoolUuid());
+            msg.setVtepUuid(vtep.getUuid());
+            bus.makeTargetServiceIdByResourceUuid(msg, L2NetworkConstant.SERVICE_ID, msg.getL2NetworkUuid());
+            bus.send(msg, new CloudBusCallBack(completion1) {
+                @Override
+                public void run(MessageReply reply) {
+                    if (!reply.isSuccess()) {
+                        logger.warn(reply.getError().toString());
+                    }
+                    completion1.done();
+                }
+            });
+        }).run(new NoErrorCompletion(completion) {
+            @Override
+            public void done() {
+                completion.success();
+            }
+        });
+    }
+
+    private List<VtepInventory> vtepFromAction(CascadeAction action) {
+        List<VtepInventory> ret = null;
+        if (L2NetworkVO.class.getSimpleName().equals(action.getParentIssuer())) {
+            List<String> l2uuids = CollectionUtils.transformToList((List<L2NetworkInventory>)action.getParentIssuerContext(), new Function<String, L2NetworkInventory>() {
+                @Override
+                public String call(L2NetworkInventory arg) {
+                    return arg.getUuid();
+                }
+            });
+
+            List<VtepVO> vos = Q.New(VtepVO.class).in(VtepVO_.poolUuid, l2uuids).list();
+            if (!vos.isEmpty()) {
+                ret = VtepInventory.valueOf(vos);
+            }
+        }  else if (NAME.equals(action.getParentIssuer())) {
+            ret = action.getParentIssuerContext();
+        }
+
+        return ret;
+    }
+
+    @Override
+    public CascadeAction createActionForChildResource(CascadeAction action) {
+        if (CascadeConstant.DELETION_CODES.contains(action.getActionCode())) {
+            List<VtepInventory> ctx = vtepFromAction(action);
+            if (ctx != null) {
+                return action.copy().setParentIssuer(NAME).setParentIssuerContext(ctx);
+            }
+        }
+
+        return null;
+    }
+}

--- a/plugin/vxlan/src/main/java/org/zstack/network/l2/vxlan/vtep/VtepInventory.java
+++ b/plugin/vxlan/src/main/java/org/zstack/network/l2/vxlan/vtep/VtepInventory.java
@@ -5,7 +5,6 @@ import org.zstack.header.query.ExpandedQueries;
 import org.zstack.header.query.ExpandedQuery;
 import org.zstack.header.query.Queryable;
 import org.zstack.header.search.Inventory;
-import org.zstack.network.l2.vxlan.vxlanNetwork.VxlanNetworkVO;
 import org.zstack.network.l2.vxlan.vxlanNetworkPool.L2VxlanNetworkPoolInventory;
 import org.zstack.network.l2.vxlan.vxlanNetworkPool.VxlanNetworkPoolVO;
 

--- a/plugin/vxlan/src/main/java/org/zstack/network/l2/vxlan/vxlanNetwork/L2VxlanNetworkInventory.java
+++ b/plugin/vxlan/src/main/java/org/zstack/network/l2/vxlan/vxlanNetwork/L2VxlanNetworkInventory.java
@@ -9,6 +9,7 @@ import org.zstack.header.query.Queryable;
 import org.zstack.header.search.Inventory;
 import org.zstack.header.search.Parent;
 import org.zstack.network.l2.vxlan.vxlanNetworkPool.L2VxlanNetworkPoolInventory;
+import org.zstack.network.l2.vxlan.vxlanNetworkPool.VxlanNetworkPoolVO;
 
 import javax.persistence.JoinColumn;
 import java.util.ArrayList;
@@ -29,7 +30,7 @@ public class L2VxlanNetworkInventory extends L2NetworkInventory {
      */
     private Integer vni;
 
-    @Queryable(mappingClass = VxlanNetworkVO.class,
+    @Queryable(mappingClass = VxlanNetworkPoolVO.class,
             joinColumn = @JoinColumn(name = "uuid", referencedColumnName = "poolUuid"))
     private String poolUuid;
 

--- a/plugin/vxlan/src/main/java/org/zstack/network/l2/vxlan/vxlanNetworkPool/KVMRealizeL2VxlanNetworkBackend.java
+++ b/plugin/vxlan/src/main/java/org/zstack/network/l2/vxlan/vxlanNetworkPool/KVMRealizeL2VxlanNetworkBackend.java
@@ -153,7 +153,7 @@ public class KVMRealizeL2VxlanNetworkBackend implements L2NetworkRealizationExte
                 msg.setPath(VXLAN_KVM_CHECK_L2VXLAN_NETWORK_PATH);
                 msg.setNoStatusCheck(noStatusCheck);
                 bus.makeTargetServiceIdByResourceUuid(msg, HostConstant.SERVICE_ID, hostUuid);
-                bus.send(msg, new CloudBusCallBack(completion) {
+                bus.send(msg, new CloudBusCallBack(trigger) {
                     @Override
                     public void run(MessageReply reply) {
                         if (!reply.isSuccess()) {
@@ -186,6 +186,7 @@ public class KVMRealizeL2VxlanNetworkBackend implements L2NetworkRealizationExte
                 if (vtepIps.contains(data.get(vtepIp))) {
                     data.put(needPopulate, false);
                     trigger.next();
+                    return;
                 } else {
                     data.put(needPopulate, true);
                 }
@@ -199,12 +200,13 @@ public class KVMRealizeL2VxlanNetworkBackend implements L2NetworkRealizationExte
                 cmsg.setType(KVM_VXLAN_TYPE);
 
                 bus.makeTargetServiceIdByResourceUuid(cmsg, L2NetworkConstant.SERVICE_ID, l2vxlan.getPoolUuid());
-                bus.send(cmsg, new CloudBusCallBack(completion) {
+                bus.send(cmsg, new CloudBusCallBack(trigger) {
                     @Override
                     public void run(MessageReply reply) {
                         if (!reply.isSuccess()) {
                             logger.warn(reply.getError().toString());
                             trigger.fail(reply.getError());
+                            return;
                         }
                         logger.debug(String.format("created new vtep [%s] on vxlan network pool [%s]", cmsg.getVtepIp(), ((L2VxlanNetworkInventory) l2Network).getPoolUuid()));
                         trigger.next();
@@ -216,53 +218,55 @@ public class KVMRealizeL2VxlanNetworkBackend implements L2NetworkRealizationExte
             public void run(FlowTrigger trigger, Map data) {
                 if (data.get(needPopulate).equals(false)) {
                     trigger.next();
+                    return;
                 }
 
                 List<VtepVO> vteps = Q.New(VtepVO.class).eq(VtepVO_.poolUuid, l2vxlan.getPoolUuid()).list();
 
                 if (vteps.size() == 1) {
-                    logger.debug("no need to populate fdb since there are only on vtep");
+                    logger.debug("no need to populate fdb since there are only one vtep");
                     trigger.next();
-                } else {
-                    new While<>(vteps).all((vtep, completion1) -> {
-                        List<String> peers = new ArrayList<>();
-                        for (VtepVO vo : vteps) {
-                            if (peers.contains(vo.getVtepIp()) || vo.getVtepIp().equals(vtep.getVtepIp())) {
-                                continue;
-                            } else {
-                                peers.add(vo.getVtepIp());
-                            }
+                    return;
+                }
+
+                new While<>(vteps).all((vtep, completion1) -> {
+                    List<String> peers = new ArrayList<>();
+                    for (VtepVO vo : vteps) {
+                        if (peers.contains(vo.getVtepIp()) || vo.getVtepIp().equals(vtep.getVtepIp())) {
+                            continue;
+                        } else {
+                            peers.add(vo.getVtepIp());
                         }
+                    }
 
-                        logger.info(String.format("populate fdb for vtep %s in vxlan network %s", vtep.getVtepIp(), l2vxlan.getUuid()));
+                    logger.info(String.format("populate fdb for vtep %s in vxlan network %s", vtep.getVtepIp(), l2vxlan.getUuid()));
 
-                        VxlanKvmAgentCommands.PopulateVxlanFdbCmd cmd = new VxlanKvmAgentCommands.PopulateVxlanFdbCmd();
-                        cmd.setPeers(peers);
-                        cmd.setVni(l2vxlan.getVni());
+                    VxlanKvmAgentCommands.PopulateVxlanFdbCmd cmd = new VxlanKvmAgentCommands.PopulateVxlanFdbCmd();
+                    cmd.setPeers(peers);
+                    cmd.setVni(l2vxlan.getVni());
 
-                        KVMHostAsyncHttpCallMsg msg = new KVMHostAsyncHttpCallMsg();
-                        msg.setHostUuid(vtep.getHostUuid());
-                        msg.setCommand(cmd);
-                        msg.setCommandTimeout(timeoutMgr.getTimeout(cmd.getClass(), "5m"));
-                        msg.setPath(VXLAN_KVM_POPULATE_FDB_L2VXLAN_NETWORK_PATH);
-                        msg.setNoStatusCheck(noStatusCheck);
-                        bus.makeTargetServiceIdByResourceUuid(msg, HostConstant.SERVICE_ID, hostUuid);
-                        bus.send(msg, new CloudBusCallBack(completion1) {
-                            @Override
-                            public void run(MessageReply reply) {
-                                if (!reply.isSuccess()) {
-                                    logger.warn(reply.getError().toString());
-                                }
-                                completion1.done();
-                            }
-                        });
-                    }).run(new NoErrorCompletion() {
+                    KVMHostAsyncHttpCallMsg msg = new KVMHostAsyncHttpCallMsg();
+                    msg.setHostUuid(vtep.getHostUuid());
+                    msg.setCommand(cmd);
+                    msg.setCommandTimeout(timeoutMgr.getTimeout(cmd.getClass(), "5m"));
+                    msg.setPath(VXLAN_KVM_POPULATE_FDB_L2VXLAN_NETWORK_PATH);
+                    msg.setNoStatusCheck(noStatusCheck);
+                    bus.makeTargetServiceIdByResourceUuid(msg, HostConstant.SERVICE_ID, hostUuid);
+                    bus.send(msg, new CloudBusCallBack(completion1) {
                         @Override
-                        public void done() {
-                            trigger.next();
+                        public void run(MessageReply reply) {
+                            if (!reply.isSuccess()) {
+                                logger.warn(reply.getError().toString());
+                            }
+                            completion1.done();
                         }
                     });
-                }
+                }).run(new NoErrorCompletion() {
+                    @Override
+                    public void done() {
+                        trigger.next();
+                    }
+                });
             }
         }).done(new FlowDoneHandler(completion) {
             @Override

--- a/plugin/vxlan/src/main/java/org/zstack/network/l2/vxlan/vxlanNetworkPool/VxlanNetworkPool.java
+++ b/plugin/vxlan/src/main/java/org/zstack/network/l2/vxlan/vxlanNetworkPool/VxlanNetworkPool.java
@@ -121,6 +121,8 @@ public class VxlanNetworkPool extends L2NoVlanNetwork implements L2VxlanNetworkP
             handle((L2NetworkDeletionMsg) msg);
         } else if (msg instanceof CreateVtepMsg) {
             handle((CreateVtepMsg) msg);
+        } else if (msg instanceof DeleteVtepMsg) {
+            handle((DeleteVtepMsg) msg);
         } else if (msg instanceof L2NetworkMessage) {
             superHandle((L2NetworkMessage) msg);
         } else {
@@ -208,6 +210,13 @@ public class VxlanNetworkPool extends L2NoVlanNetwork implements L2VxlanNetworkP
         bus.reply(msg, reply);
     }
 
+    private void handle(DeleteVtepMsg msg) {
+        DeleteVtepReply reply = new DeleteVtepReply();
+        VtepVO vo = dbf.findByUuid(msg.getVtepUuid(), VtepVO.class);
+        dbf.remove(vo);
+        bus.reply(msg, reply);
+    }
+
     private void handleApiMessage(APIMessage msg) {
         if (msg instanceof APIDeleteL2NetworkMsg) {
             handle((APIDeleteL2NetworkMsg) msg);
@@ -240,6 +249,7 @@ public class VxlanNetworkPool extends L2NoVlanNetwork implements L2VxlanNetworkP
                 if (uuids.isEmpty()) {
                     logger.info(String.format("There are no vxlan networks for vxlan pool %s", msg.getL2NetworkUuid()));
                     trigger.next();
+                    return;
                 }
 
                 logger.info(String.format("Detach l2 vxlan networks %s for vxlan pool %s", uuids, msg.getL2NetworkUuid()));


### PR DESCRIPTION
Implement vtep cascade delete when deleting or detaching l2network.
Besides, fix vxlan network inventory bug, fix it print
"Completion.success() is mistakenly called twice" in management log at
some case.

For: zstackio/issues#3206
For: zstackio/issues#3185