### PR TITLE
try to fix an unstable case

### DIFF
--- a/test/src/test/groovy/org/zstack/test/integration/storage/primary/ceph/AddCephPrimaryStorageCase.groovy
+++ b/test/src/test/groovy/org/zstack/test/integration/storage/primary/ceph/AddCephPrimaryStorageCase.groovy
@@ -18,8 +18,6 @@ import org.zstack.testlib.Test
 import org.zstack.utils.Utils
 import org.zstack.utils.logging.CLogger
 
-import java.util.concurrent.TimeUnit
-
 import static org.zstack.core.Platform.operr
 
 // maybe unstable case
@@ -127,7 +125,10 @@ use:
         // wait echo finished
         // todo; unstable assert
         retryInSecs{
-            assert Q.New(CephPrimaryStorageMonVO.class).count() == 0l: "failed to add cephPS, all monVO should be removed, but some left"
+            logger.error("unstable assert count")
+            return {
+                assert Q.New(CephPrimaryStorageMonVO.class).count() == 0l: "after failed to add cephPS, all monVO should be removed, but some left"
+            }
         }
     }
 


### PR DESCRIPTION
这个case大概一周会出错一到两次。
相关现象：
case成功时需要用完retryInSecs全部的默认15秒；调整成5秒，会用完全部的默认5秒。添加return后则成功立刻返回，和groovy默认的返回最后一行的行为不符。

case失败时，整个case只执行了2秒多一点，无法解释为什么没有尝试默认的15秒。
故：
添加return
添加retry尝试的log输出。