### PR TITLE
Fix bug that should use pool physical interface to check vtep ip

### DIFF
--- a/plugin/vxlan/src/main/java/org/zstack/network/l2/vxlan/vxlanNetwork/VxlanNetworkFactory.java
+++ b/plugin/vxlan/src/main/java/org/zstack/network/l2/vxlan/vxlanNetwork/VxlanNetworkFactory.java
@@ -54,7 +54,7 @@ public class VxlanNetworkFactory implements L2NetworkFactory, Component {
         vo.setVni(r.getVni());
         vo.setPoolUuid((amsg.getPoolUuid()));
         if (vo.getPhysicalInterface() == null) {
-            vo.setPhysicalInterface("No use");
+            vo.setPhysicalInterface("");
         }
         vo = dbf.persistAndRefresh(vo);
 

--- a/plugin/vxlan/src/main/java/org/zstack/network/l2/vxlan/vxlanNetworkPool/KVMRealizeL2VxlanNetworkBackend.java
+++ b/plugin/vxlan/src/main/java/org/zstack/network/l2/vxlan/vxlanNetworkPool/KVMRealizeL2VxlanNetworkBackend.java
@@ -134,6 +134,7 @@ public class KVMRealizeL2VxlanNetworkBackend implements L2NetworkRealizationExte
     public void check(L2NetworkInventory l2Network, String hostUuid, boolean noStatusCheck, Completion completion) {
         final L2VxlanNetworkInventory l2vxlan = (L2VxlanNetworkInventory) l2Network;
         final String clusterUuid = Q.New(HostVO.class).select(HostVO_.clusterUuid).eq(HostVO_.uuid, hostUuid).findValue();
+        final VxlanNetworkPoolVO poolVO = Q.New(VxlanNetworkPoolVO.class).eq(VxlanNetworkPoolVO_.uuid, l2vxlan.getPoolUuid()).find();
 
         FlowChain chain = FlowChainBuilder.newSimpleFlowChain();
         chain.setName(String.format("check-l2-vxlan-%s-on-host-%s", l2Network.getUuid(), hostUuid));
@@ -142,8 +143,8 @@ public class KVMRealizeL2VxlanNetworkBackend implements L2NetworkRealizationExte
             public void run(FlowTrigger trigger, Map data) {
                 VxlanKvmAgentCommands.CheckVxlanCidrCmd cmd = new VxlanKvmAgentCommands.CheckVxlanCidrCmd();
                 cmd.setCidr(getAttachedCidrs(l2vxlan.getPoolUuid()).get(clusterUuid));
-                if (!l2Network.getPhysicalInterface().equals("No use")) {
-                    cmd.setPhysicalInterfaceName(l2Network.getPhysicalInterface());
+                if (!poolVO.getPhysicalInterface().isEmpty()) {
+                    cmd.setPhysicalInterfaceName(poolVO.getPhysicalInterface());
                 }
 
                 KVMHostAsyncHttpCallMsg msg = new KVMHostAsyncHttpCallMsg();

--- a/plugin/vxlan/src/main/java/org/zstack/network/l2/vxlan/vxlanNetworkPool/KVMRealizeL2VxlanNetworkPoolBackend.java
+++ b/plugin/vxlan/src/main/java/org/zstack/network/l2/vxlan/vxlanNetworkPool/KVMRealizeL2VxlanNetworkPoolBackend.java
@@ -69,7 +69,7 @@ public class KVMRealizeL2VxlanNetworkPoolBackend implements L2NetworkRealization
 
         VxlanKvmAgentCommands.CheckVxlanCidrCmd cmd = new VxlanKvmAgentCommands.CheckVxlanCidrCmd();
         cmd.setCidr(getAttachedCidrs(vxlanPool.getUuid()).get(clusterUuid));
-        if (!l2Network.getPhysicalInterface().equals("No use")) {
+        if (!l2Network.getPhysicalInterface().isEmpty()) {
             cmd.setPhysicalInterfaceName(l2Network.getPhysicalInterface());
         }
 
@@ -128,7 +128,6 @@ public class KVMRealizeL2VxlanNetworkPoolBackend implements L2NetworkRealization
         KVMAgentCommands.NicTO to = new KVMAgentCommands.NicTO();
         to.setMac(nic.getMac());
         to.setUuid(nic.getUuid());
-        to.setBridgeName("No use");
         to.setDeviceId(nic.getDeviceId());
         to.setNicInternalName(nic.getInternalName());
         return to;

--- a/plugin/vxlan/src/main/java/org/zstack/network/l2/vxlan/vxlanNetworkPool/VxlanNetworkPoolFactory.java
+++ b/plugin/vxlan/src/main/java/org/zstack/network/l2/vxlan/vxlanNetworkPool/VxlanNetworkPoolFactory.java
@@ -33,7 +33,7 @@ public class VxlanNetworkPoolFactory implements L2NetworkFactory, Component {
     public L2NetworkInventory createL2Network(L2NetworkVO ovo, APICreateL2NetworkMsg msg) {
         VxlanNetworkPoolVO vo = new VxlanNetworkPoolVO(ovo);
         if (vo.getPhysicalInterface() == null) {
-            vo.setPhysicalInterface("No use");
+            vo.setPhysicalInterface("");
         }
         vo = dbf.persistAndRefresh(vo);
         L2VxlanNetworkPoolInventory inv = L2VxlanNetworkPoolInventory.valueOf(vo);


### PR DESCRIPTION
Check vtep ip in KVMRealizeL2VxlanNetworkBackend should use physical
interface in pool rather than vxlan network.

Besides, change 'No use' to empty string for actually physical interface
can be useful.