### PR TITLE
Fix live migrate for vxlan network

### DIFF
--- a/conf/springConfigXml/vxlan.xml
+++ b/conf/springConfigXml/vxlan.xml
@@ -54,6 +54,13 @@
         </zstack:plugin>
     </bean>
 
+    <bean id="L2VxlanNetwork" class="org.zstack.network.l2.vxlan.vxlanNetwork.VxlanNetwork">
+        <zstack:plugin>
+            <zstack:extension interface="org.zstack.header.network.l2.L2Network" />
+            <zstack:extension interface="org.zstack.header.vm.VmInstanceMigrateExtensionPoint" />
+        </zstack:plugin>
+    </bean>
+
     <bean id="VxlanNetworkChecker" class="org.zstack.network.l2.vxlan.vxlanNetworkPool.VxlanNetworkCheckerImpl" />
 
     <bean id="KVMConnectExtensionForVxlanNetwork" class="org.zstack.network.l2.vxlan.vxlanNetworkPool.KVMConnectExtensionForVxlanNetwork">

--- a/plugin/vxlan/src/main/java/org/zstack/network/l2/vxlan/vtep/VtepCascadeExtension.java
+++ b/plugin/vxlan/src/main/java/org/zstack/network/l2/vxlan/vtep/VtepCascadeExtension.java
@@ -101,6 +101,11 @@ public class VtepCascadeExtension extends AbstractAsyncCascadeExtension {
     private void handleDeletion(final CascadeAction action, final Completion completion) {
         List<VtepInventory> vteps = vtepFromAction(action);
 
+        if (vteps == null) {
+            completion.success();
+            return;
+        }
+
         new While<>(vteps).all((vtep, completion1) -> {
             DeleteVtepMsg msg = new DeleteVtepMsg();
             msg.setL2NetworkUuid(vtep.getPoolUuid());

--- a/plugin/vxlan/src/main/java/org/zstack/network/l2/vxlan/vxlanNetwork/L2VxlanNetworkInventory.java
+++ b/plugin/vxlan/src/main/java/org/zstack/network/l2/vxlan/vxlanNetwork/L2VxlanNetworkInventory.java
@@ -30,8 +30,6 @@ public class L2VxlanNetworkInventory extends L2NetworkInventory {
      */
     private Integer vni;
 
-    @Queryable(mappingClass = VxlanNetworkPoolVO.class,
-            joinColumn = @JoinColumn(name = "uuid", referencedColumnName = "poolUuid"))
     private String poolUuid;
 
     public L2VxlanNetworkInventory() {

--- a/test/src/test/groovy/org/zstack/test/integration/network/NetworkTest.groovy
+++ b/test/src/test/groovy/org/zstack/test/integration/network/NetworkTest.groovy
@@ -15,6 +15,7 @@ class NetworkTest extends Test {
         sftpBackupStorage()
         flatNetwork()
         securityGroup()
+        nfsPrimaryStorage()
         include("vip.xml")
         include("vxlan.xml")
     }


### PR DESCRIPTION
Add VmInstanceMigrateExtensionPoint for vxlan network.
Fix that create vtep occasionally show ConstraintViolationException.

For: zstackio/issues#3468
For: zstackio/issues#3504