### PR TITLE
fix bug 3557

### DIFF
--- a/compute/src/main/java/org/zstack/compute/allocator/HostPrimaryStorageAllocatorFlow.java
+++ b/compute/src/main/java/org/zstack/compute/allocator/HostPrimaryStorageAllocatorFlow.java
@@ -57,12 +57,14 @@ public class HostPrimaryStorageAllocatorFlow extends AbstractHostAllocatorFlow {
                 " and ps.state = :state" +
                 " and ps.status = :status" +
                 " and ref.clusterUuid = h.clusterUuid" +
-                " and h.uuid in (:huuids)";
+                " and h.uuid in (:huuids)"+
+                " and cap.availableCapacity > :rootVolumeSize";
 
         TypedQuery<Tuple> q = dbf.getEntityManager().createQuery(sql, Tuple.class);
         q.setParameter("state", PrimaryStorageState.Enabled);
         q.setParameter("status", PrimaryStorageStatus.Connected);
         q.setParameter("huuids", huuids);
+        q.setParameter("rootVolumeSize", spec.getDiskSize());
         List<Tuple> ts = q.getResultList();
         if (ts.isEmpty()) {
             return new ArrayList<>();


### PR DESCRIPTION
for https://github.com/zstackio/issues/issues/3557

偶尔会出现这种情况，指定较大的云盘但是创建失败，因为存储容量不够。加了一个判断逻辑。