### PR TITLE
Ser L2VxlanNetwork run first in VmInstanceMigrateExtensionPoint

### DIFF
--- a/conf/springConfigXml/vxlan.xml
+++ b/conf/springConfigXml/vxlan.xml
@@ -57,7 +57,7 @@
     <bean id="L2VxlanNetwork" class="org.zstack.network.l2.vxlan.vxlanNetwork.VxlanNetwork">
         <zstack:plugin>
             <zstack:extension interface="org.zstack.header.network.l2.L2Network" />
-            <zstack:extension interface="org.zstack.header.vm.VmInstanceMigrateExtensionPoint" />
+            <zstack:extension interface="org.zstack.header.vm.VmInstanceMigrateExtensionPoint" order="9999"/>
         </zstack:plugin>
     </bean>
 


### PR DESCRIPTION
Dhcp should run after vxlan.

For zstackio/issues#3468