### PR TITLE
Make vxlan range check more strict

### DIFF
--- a/plugin/vxlan/src/main/java/org/zstack/network/l2/vxlan/vxlanNetworkPool/KVMRealizeL2VxlanNetworkBackend.java
+++ b/plugin/vxlan/src/main/java/org/zstack/network/l2/vxlan/vxlanNetworkPool/KVMRealizeL2VxlanNetworkBackend.java
@@ -58,7 +58,7 @@ public class KVMRealizeL2VxlanNetworkBackend implements L2NetworkRealizationExte
     private static String needPopulate = "needPopulate";
 
     private String makeBridgeName(int vxlan) {
-        return String.format("br_vxlan_%s",vxlan);
+        return String.format("br_vx_%s",vxlan);
     }
 
     @Override

--- a/plugin/vxlan/src/main/java/org/zstack/network/l2/vxlan/vxlanNetworkPool/L2VxlanNetworkPoolInventory.java
+++ b/plugin/vxlan/src/main/java/org/zstack/network/l2/vxlan/vxlanNetworkPool/L2VxlanNetworkPoolInventory.java
@@ -15,6 +15,7 @@ import org.zstack.network.l2.vxlan.vxlanNetwork.VxlanNetworkVO;
 
 import javax.persistence.JoinColumn;
 import java.util.*;
+import java.util.regex.Pattern;
 
 @PythonClassInventory
 @Inventory(mappingVOClass = VxlanNetworkPoolVO.class, collectionValueOfMethod = "valueOf1",
@@ -48,8 +49,12 @@ public class L2VxlanNetworkPoolInventory extends L2NetworkInventory {
 
     protected L2VxlanNetworkPoolInventory(VxlanNetworkPoolVO vo) {
         super(vo);
+        String patern = "\\{.*\\}";
         attachedCidrs = new HashMap<>();
         for (Map<String, String> tag : VxlanSystemTags.VXLAN_POOL_CLUSTER_VTEP_CIDR.getTokensOfTagsByResourceUuid(vo.getUuid())) {
+            if (!Pattern.matches(patern, tag.get(VxlanSystemTags.VTEP_CIDR_TOKEN))) {
+                continue;
+            }
             attachedCidrs.put(tag.get(VxlanSystemTags.CLUSTER_UUID_TOKEN),
                     tag.get(VxlanSystemTags.VTEP_CIDR_TOKEN).split("[{}]")[1]);
         }


### PR DESCRIPTION
If the pool to attach cluster has overlapped vni range with existing
pool which attached with the cluster, it may cause some network
problems.

Besides, the bridge name now is too long that maybe cut by brctl.

Add check in inventory to avoid exception if user add invalid system tag.

For zstackio/issues#3712