### PR TITLE
Fix bug nfs capacity @@2

### DIFF
--- a/plugin/nfsPrimaryStorage/src/main/java/org/zstack/storage/primary/nfs/NfsPrimaryStorageKVMBackend.java
+++ b/plugin/nfsPrimaryStorage/src/main/java/org/zstack/storage/primary/nfs/NfsPrimaryStorageKVMBackend.java
@@ -1177,6 +1177,12 @@ public class NfsPrimaryStorageKVMBackend implements NfsPrimaryStorageBackend,
                                 }
                             });
 
+                            // update ps availableCapacity
+                            RecalculatePrimaryStorageCapacityMsg msg = new RecalculatePrimaryStorageCapacityMsg();
+                            msg.setPrimaryStorageUuid(inv.getUuid());
+                            bus.makeTargetServiceIdByResourceUuid(msg, PrimaryStorageConstant.SERVICE_ID, inv.getUuid());
+                            bus.send(msg);
+
                             if (!PrimaryStorageStatus.Connected.toString().equals(inv.getStatus())) {
                                 // use sync call here to make sure the NFS primary storage connected before continue to the next step
                                 ChangePrimaryStorageStatusMsg cmsg = new ChangePrimaryStorageStatusMsg();

--- a/plugin/nfsPrimaryStorage/src/main/java/org/zstack/storage/primary/nfs/NfsPrimaryStorageKVMBackend.java
+++ b/plugin/nfsPrimaryStorage/src/main/java/org/zstack/storage/primary/nfs/NfsPrimaryStorageKVMBackend.java
@@ -1165,12 +1165,11 @@ public class NfsPrimaryStorageKVMBackend implements NfsPrimaryStorageBackend,
                             new PrimaryStorageCapacityUpdater(inv.getUuid()).run(new PrimaryStorageCapacityUpdaterRunnable() {
                                 @Override
                                 public PrimaryStorageCapacityVO call(PrimaryStorageCapacityVO cap) {
-                                    if (cap.getTotalCapacity() == 0 && cap.getAvailableCapacity() == 0) {
-                                        // init
-                                        cap.setTotalCapacity(rsp.getTotalCapacity());
-                                        cap.setAvailableCapacity(rsp.getAvailableCapacity());
-                                    }
 
+                                    // Do not directly update availableCapacity, because availableCapacity is not equal to availablePhysicalCapacity
+                                    // cap.setAvailableCapacity(rsp.getAvailableCapacity());
+
+                                    cap.setTotalCapacity(rsp.getTotalCapacity());
                                     cap.setTotalPhysicalCapacity(rsp.getTotalCapacity());
                                     cap.setAvailablePhysicalCapacity(rsp.getAvailableCapacity());
 

--- a/test/src/test/groovy/org/zstack/test/integration/storage/primary/nfs/capacity/AttachNfsWhenNoConnectedHostCase.groovy
+++ b/test/src/test/groovy/org/zstack/test/integration/storage/primary/nfs/capacity/AttachNfsWhenNoConnectedHostCase.groovy
@@ -1,0 +1,183 @@
+package org.zstack.test.integration.storage.primary.nfs.capacity
+
+import org.springframework.http.HttpEntity
+import org.zstack.header.image.ImageConstant
+import org.zstack.header.network.service.NetworkServiceType
+import org.zstack.kvm.KVMConstant
+import org.zstack.network.securitygroup.SecurityGroupConstant
+import org.zstack.network.service.virtualrouter.VirtualRouterConstant
+import org.zstack.sdk.*
+import org.zstack.test.integration.storage.StorageTest
+import org.zstack.testlib.EnvSpec
+import org.zstack.testlib.SubCase
+import org.zstack.testlib.Test
+import org.zstack.utils.data.SizeUnit
+
+/**
+ * Created by lining on 2017/5/19.
+ */
+class AttachNfsWhenNoConnectedHostCase extends SubCase {
+    EnvSpec env
+
+    @Override
+    void clean() {
+        env.delete()
+    }
+
+    @Override
+    void setup() {
+        useSpring(StorageTest.springSpec)
+    }
+
+    @Override
+    void environment() {
+        env = env {
+            instanceOffering {
+                name = "instanceOffering"
+                memory = SizeUnit.GIGABYTE.toByte(8)
+                cpu = 4
+            }
+
+            diskOffering {
+                name = "diskOffering"
+                diskSize = SizeUnit.GIGABYTE.toByte(20)
+            }
+
+            sftpBackupStorage {
+                name = "sftp"
+                url = "/sftp"
+                username = "root"
+                password = "password"
+                hostname = "localhost"
+
+                image {
+                    name = "iso"
+                    url = "http://zstack.org/download/test.iso"
+                    mediaType = ImageConstant.ImageMediaType.ISO.toString()
+                }
+            }
+
+            zone {
+                name = "zone"
+                description = "test"
+
+                cluster {
+                    name = "cluster"
+                    hypervisorType = "KVM"
+
+                    kvm {
+                        name = "kvm"
+                        managementIp = "localhost"
+                        username = "root"
+                        password = "password"
+                    }
+
+                    attachPrimaryStorage("nfs")
+                    attachL2Network("l2")
+                }
+
+                nfsPrimaryStorage {
+                    name = "nfs"
+                    url = "localhost:/nfs"
+                }
+
+                l2NoVlanNetwork {
+                    name = "l2"
+                    physicalInterface = "eth0"
+
+                    l3Network {
+                        name = "l3"
+
+                        ip {
+                            startIp = "192.168.100.10"
+                            endIp = "192.168.100.100"
+                            netmask = "255.255.255.0"
+                            gateway = "192.168.100.1"
+                        }
+                    }
+                }
+
+                attachBackupStorage("sftp")
+            }
+
+            vm {
+                name = "vm"
+                useInstanceOffering("instanceOffering")
+                useImage("iso")
+                useL3Networks("l3")
+                useRootDiskOffering("diskOffering")
+                useHost("kvm")
+            }
+        }
+    }
+
+    @Override
+    void test() {
+        env.create {
+            testReconnectPrimaryStorageCapacityRecalculation()
+        }
+    }
+
+    void testReconnectPrimaryStorageCapacityRecalculation() {
+        PrimaryStorageInventory ps = env.inventoryByName("nfs")
+        L3NetworkInventory l3 = env.inventoryByName("l3")
+        ClusterInventory clusterInventory = env.inventoryByName("cluster")
+        HostInventory hostInventory = env.inventoryByName("kvm")
+
+        GetPrimaryStorageCapacityResult beforeCapacity = getPrimaryStorageCapacity {
+            primaryStorageUuids = [ps.uuid]
+        }
+
+        detachPrimaryStorageFromCluster {
+            primaryStorageUuid = ps.uuid
+            clusterUuid = clusterInventory.uuid
+        }
+        GetPrimaryStorageCapacityResult capacity = getPrimaryStorageCapacity {
+            primaryStorageUuids = [ps.uuid]
+        }
+        retryInSecs(2){
+            assert 0 == capacity.availableCapacity
+            assert 0 == capacity.availablePhysicalCapacity
+            assert 0 == capacity.totalPhysicalCapacity
+            assert 0 == capacity.totalCapacity
+        }
+
+        env.afterSimulator(KVMConstant.KVM_CONNECT_PATH) { rsp, HttpEntity<String> e ->
+            rsp.success = false
+            return rsp
+        }
+        // mock connect fail
+        ReconnectHostAction reconnectHostAction = new ReconnectHostAction(
+                uuid: hostInventory.uuid,
+                sessionId: Test.currentEnvSpec?.session?.uuid
+        )
+        assert null != reconnectHostAction.call().error
+
+        attachPrimaryStorageToCluster {
+            primaryStorageUuid = ps.uuid
+            clusterUuid = clusterInventory.uuid
+        }
+        capacity = getPrimaryStorageCapacity {
+            primaryStorageUuids = [ps.uuid]
+        }
+        assert 0 != capacity.availableCapacity
+        assert 0 == capacity.availablePhysicalCapacity
+        assert 0 == capacity.totalPhysicalCapacity
+        assert 0 == capacity.totalCapacity
+
+        env.afterSimulator(KVMConstant.KVM_CONNECT_PATH) { rsp, HttpEntity<String> e ->
+            rsp.success = true
+            return rsp
+        }
+        reconnectHost {
+            uuid = hostInventory.uuid
+        }
+        capacity = getPrimaryStorageCapacity {
+            primaryStorageUuids = [ps.uuid]
+        }
+        assert 0 != capacity.availableCapacity
+        assert 0 != capacity.availablePhysicalCapacity
+        assert 0 != capacity.totalPhysicalCapacity
+        assert 0 != capacity.totalCapacity
+    }
+}


### PR DESCRIPTION
背景：nfs 主存储 totalCapacity错误，始终为0

totalCapacity错误，复现流程：
1.选择nfs ps, 创建vm
2.卸载nfs, 卸载后，ps所有容量（可用容量，总容量，可用物理容量，总物理容量）都为0
3.把当前集群所有物理机全部设置为disconnected
**4.挂载之前卸载的nfs，挂载后，因为无connected 物理机，所以获取不到nfs容量信息，
最后ps 可用容量为负数，而总容量，可用物理容量，总物理容量都为0 （符合预期）
5.重连host，代码有bug，没有去更新总容量，就导致了总容量一直为0**