### PR TITLE
Fix add-dns overwrite all dns rather than add dns

### DIFF
--- a/plugin/flatNetworkProvider/src/main/java/org/zstack/network/service/flat/FlatDnsBackend.java
+++ b/plugin/flatNetworkProvider/src/main/java/org/zstack/network/service/flat/FlatDnsBackend.java
@@ -165,7 +165,7 @@ public class FlatDnsBackend implements NetworkServiceDnsBackend, KVMHostConnectE
             @Override
             public KVMHostAsyncHttpCallMsg call(String huuid) {
                 SetDnsCmd cmd = new SetDnsCmd();
-                cmd.dns = dns;
+                cmd.dns = l3.getDns();
 
                 KVMHostAsyncHttpCallMsg msg = new KVMHostAsyncHttpCallMsg();
                 msg.setCommand(cmd);

--- a/plugin/virtualRouterProvider/src/main/java/org/zstack/network/service/virtualrouter/dns/VirtualRouterDnsBackend.java
+++ b/plugin/virtualRouterProvider/src/main/java/org/zstack/network/service/virtualrouter/dns/VirtualRouterDnsBackend.java
@@ -58,7 +58,7 @@ public class VirtualRouterDnsBackend extends AbstractVirtualRouterBackend implem
         }
 
         SetDnsCmd cmd = new SetDnsCmd();
-        cmd.setDns(CollectionUtils.transformToList(dns, new Function<DnsInfo, String>() {
+        cmd.setDns(CollectionUtils.transformToList(l3.getDns(), new Function<DnsInfo, String>() {
             @Override
             public DnsInfo call(String arg) {
                 DnsInfo info = new DnsInfo();

--- a/test/src/test/groovy/org/zstack/test/integration/networkservice/provider/flat/dns/FlatAddDnsCase.groovy
+++ b/test/src/test/groovy/org/zstack/test/integration/networkservice/provider/flat/dns/FlatAddDnsCase.groovy
@@ -1,0 +1,67 @@
+package org.zstack.test.integration.networkservice.provider.flat.dns
+
+import org.springframework.http.HttpEntity
+import org.zstack.network.service.flat.FlatDnsBackend
+import org.zstack.sdk.L3NetworkInventory
+import org.zstack.test.integration.networkservice.provider.NetworkServiceProviderTest
+import org.zstack.test.integration.networkservice.provider.flat.FlatNetworkServiceEnv
+import org.zstack.testlib.EnvSpec
+import org.zstack.testlib.L3NetworkSpec
+import org.zstack.testlib.SubCase
+import org.zstack.utils.gson.JSONObjectUtil
+
+/**
+ * Created by weiwang on 25/05/2017.
+ */
+class FlatAddDnsCase extends SubCase {
+    EnvSpec env
+
+    L3NetworkInventory l3
+    String dns1 = "8.8.8.8"
+    String dns2 = "8.8.4.4"
+
+    @Override
+    void clean() {
+        env.cleanSimulatorHandlers();
+        env.delete()
+    }
+
+
+    @Override
+    void setup() {
+        useSpring(NetworkServiceProviderTest.springSpec)
+    }
+
+    @Override
+    void environment() {
+        env = FlatNetworkServiceEnv.oneFlatEipEnv()
+    }
+
+    void testAddDns() {
+        FlatDnsBackend.SetDnsCmd cmd = null
+
+        env.afterSimulator(FlatDnsBackend.SET_DNS_PATH) { rsp, HttpEntity<String> e ->
+            cmd = JSONObjectUtil.toObject(e.body, FlatDnsBackend.SetDnsCmd.class)
+            return rsp
+        }
+
+        addDnsToL3Network {
+            delegate.l3NetworkUuid = l3.getUuid()
+            delegate.dns = dns1
+        }
+
+        assert cmd == null
+        // Note(WeiW): Yes, actually though setDns of FlatDnsBackend has been implemented,
+        // but workflow will always return in
+        // org.zstack.network.service.DnsExtension.handle(org.zstack.header.network.service.AddDnsMsg),
+        // because the ptype is null
+    }
+
+    @Override
+    void test() {
+        env.create {
+            l3 = (env.specByName("l3") as L3NetworkSpec).inventory
+            testAddDns()
+        }
+    }
+}

--- a/test/src/test/groovy/org/zstack/test/integration/networkservice/provider/virtualrouter/dns/VirtualRouterAddDnsCase.groovy
+++ b/test/src/test/groovy/org/zstack/test/integration/networkservice/provider/virtualrouter/dns/VirtualRouterAddDnsCase.groovy
@@ -1,0 +1,78 @@
+package org.zstack.test.integration.networkservice.provider.virtualrouter.dns
+
+import org.springframework.http.HttpEntity
+import org.zstack.network.service.virtualrouter.VirtualRouterCommands
+import org.zstack.network.service.virtualrouter.VirtualRouterConstant
+import org.zstack.sdk.L3NetworkInventory
+import org.zstack.test.integration.networkservice.provider.NetworkServiceProviderTest
+import org.zstack.test.integration.networkservice.provider.virtualrouter.VirtualRouterNetworkServiceEnv
+import org.zstack.testlib.EnvSpec
+import org.zstack.testlib.L3NetworkSpec
+import org.zstack.testlib.SubCase
+import org.zstack.utils.gson.JSONObjectUtil
+
+/**
+ * Created by weiwang on 25/05/2017.
+ */
+class VirtualRouterAddDnsCase extends SubCase {
+    EnvSpec env
+
+    L3NetworkInventory l3
+    String dns1 = "8.8.8.8"
+    String dns2 = "8.8.4.4"
+
+    @Override
+    void clean() {
+        env.cleanSimulatorHandlers();
+        env.delete()
+    }
+
+    @Override
+    void setup() {
+        useSpring(NetworkServiceProviderTest.springSpec)
+    }
+
+    @Override
+    void environment() {
+        env = VirtualRouterNetworkServiceEnv.oneVmOneHostVyosOnEipEnv()
+    }
+
+    void testAddDns() {
+        VirtualRouterCommands.SetDnsCmd cmd = null
+
+        env.afterSimulator(VirtualRouterConstant.VR_SET_DNS_PATH) { rsp, HttpEntity<String> e ->
+            cmd = JSONObjectUtil.toObject(e.body, VirtualRouterCommands.SetDnsCmd.class)
+            return rsp
+        }
+
+        addDnsToL3Network {
+            delegate.l3NetworkUuid = l3.getUuid()
+            delegate.dns = dns1
+        }
+
+        assert cmd != null
+        assert cmd.dns.stream()
+                      .map { dnsinfo -> dnsinfo.dnsAddress }
+                      .collect()
+                      .contains(dns1)
+
+        addDnsToL3Network {
+            delegate.l3NetworkUuid = l3.getUuid()
+            delegate.dns = dns2
+        }
+
+        assert cmd != null
+        assert cmd.dns.stream()
+                      .map { dnsinfo -> dnsinfo.dnsAddress }
+                      .collect()
+                      .containsAll([dns1, dns2])
+    }
+
+    @Override
+    void test() {
+        env.create {
+            l3 = (env.specByName("l3") as L3NetworkSpec).inventory
+            testAddDns()
+        }
+    }
+}


### PR DESCRIPTION
AddDnsToL3Network will mapping to '/setdns' api in vyos and flat backend,
it will clear all dns first and add the latest one, rather than only add
the new one;

For zstackio/issues#3925