### PR TITLE
fix bug VmInstanceVO no zoneUuid

### DIFF
--- a/compute/src/main/java/org/zstack/compute/vm/VmInstanceManagerImpl.java
+++ b/compute/src/main/java/org/zstack/compute/vm/VmInstanceManagerImpl.java
@@ -718,6 +718,17 @@ public class VmInstanceManagerImpl extends AbstractService implements
     private CreateVmInstanceMsg fromAPICreateVmInstanceMsg(APICreateVmInstanceMsg msg) {
         CreateVmInstanceMsg cmsg = new CreateVmInstanceMsg();
 
+
+        if(msg.getZoneUuid() != null){
+            cmsg.setZoneUuid(msg.getZoneUuid());
+        }else{
+            String zoneUuid = Q.New(L3NetworkVO.class)
+                    .select(L3NetworkVO_.zoneUuid)
+                    .eq(L3NetworkVO_.uuid, msg.getL3NetworkUuids().get(0))
+                    .findValue();
+            cmsg.setZoneUuid(zoneUuid);
+        }
+
         InstanceOfferingVO iovo = dbf.findByUuid(msg.getInstanceOfferingUuid(), InstanceOfferingVO.class);
         cmsg.setInstanceOfferingUuid(iovo.getUuid());
         cmsg.setCpuNum(iovo.getCpuNum());
@@ -732,7 +743,7 @@ public class VmInstanceManagerImpl extends AbstractService implements
         cmsg.setType(msg.getType());
         cmsg.setRootDiskOfferingUuid(msg.getRootDiskOfferingUuid());
         cmsg.setDataDiskOfferingUuids(msg.getDataDiskOfferingUuids());
-        cmsg.setZoneUuid(msg.getZoneUuid());
+
         cmsg.setClusterUuid(msg.getClusterUuid());
         cmsg.setHostUuid(msg.getHostUuid());
         cmsg.setPrimaryStorageUuidForRootVolume(msg.getPrimaryStorageUuidForRootVolume());


### PR DESCRIPTION
批量创建vm时，如果创建未完成时，重启了管理节点或者重启zstack，会导致未创建完毕的vm处于中间状态，没有zoneUuid（没有zoneUuid，会导致UI 2.0无法显示vm list，用户也无法删除这批vm）

目前解决方案为：在VmInstanceVO第一次写入db时，带上zoneUuid，防止此类情况发生