### PR TITLE
fix bug 2323

### DIFF
--- a/image/src/main/java/org/zstack/image/ImageManagerImpl.java
+++ b/image/src/main/java/org/zstack/image/ImageManagerImpl.java
@@ -2,6 +2,7 @@ package org.zstack.image;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.annotation.Transactional;
+import org.zstack.core.CoreGlobalProperty;
 import org.zstack.core.Platform;
 import org.zstack.core.asyncbatch.AsyncBatchRunner;
 import org.zstack.core.asyncbatch.LoopAsyncBatch;
@@ -378,7 +379,7 @@ public class ImageManagerImpl extends AbstractService implements ImageManager, M
 
                                 if (fail == backupStorageNum) {
                                     ErrorCode errCode = operr("failed to create data volume template from volume[uuid:%s] on all backup storage%s. See cause for one of errors",
-                                                    msg.getVolumeUuid(), msg.getBackupStorageUuids()).causedBy(err);
+                                            msg.getVolumeUuid(), msg.getBackupStorageUuids()).causedBy(err);
 
                                     trigger.fail(errCode);
                                 } else {
@@ -889,6 +890,10 @@ public class ImageManagerImpl extends AbstractService implements ImageManager, M
             vo.setUuid(Platform.getUuid());
         }
 
+        if (!CoreGlobalProperty.UNIT_TEST_ON){
+            long imageSizeAsked = new ImageQuotaUtil().getImageSizeQuotaUseHttpHead(msg);
+            vo.setActualSize(imageSizeAsked);
+        }
         vo.setName(msg.getName());
         vo.setDescription(msg.getDescription());
         if (msg.getFormat().equals(ImageConstant.ISO_FORMAT_STRING)) {
@@ -1356,7 +1361,7 @@ public class ImageManagerImpl extends AbstractService implements ImageManager, M
                     quotaCompareInfo.request = imageNumAsked;
                     new QuotaUtil().CheckQuota(quotaCompareInfo);
                 }
-                new ImageQuotaUtil().checkImageSizeQuotaUseHttpHead(msg, pairs);
+                new ImageQuotaUtil().getImageSizeQuotaUseHttpHead(msg, pairs);
             }
         };
 

--- a/image/src/main/java/org/zstack/image/ImageQuotaUtil.java
+++ b/image/src/main/java/org/zstack/image/ImageQuotaUtil.java
@@ -89,14 +89,22 @@ public class ImageQuotaUtil {
     }
 
     @BypassWhenUnitTest
-    public void checkImageSizeQuotaUseHttpHead(APIAddImageMsg msg, Map<String, Quota.QuotaPair> pairs) {
+    public void getImageSizeQuotaUseHttpHead(APIAddImageMsg msg, Map<String, Quota.QuotaPair> pairs) {
         long imageSizeQuota = pairs.get(ImageConstant.QUOTA_IMAGE_SIZE).getValue();
         long imageSizeUsed = new ImageQuotaUtil().getUsedImageSize(msg.getSession().getAccountUuid());
+        long imageSizeAsked = getImageSizeQuotaUseHttpHead(msg);
+        if ((imageSizeQuota == 0) || (imageSizeUsed + imageSizeAsked > imageSizeQuota)) {
+            throw new ApiMessageInterceptionException(errf.instantiateErrorCode(IdentityErrors.QUOTA_EXCEEDING,
+                    String.format("quota exceeding. The account[uuid: %s] exceeds a quota[name: %s, value: %s]",
+                            msg.getSession().getAccountUuid(), ImageConstant.QUOTA_IMAGE_SIZE, imageSizeQuota)
+            ));
+        }
+    }
 
-        long imageSizeAsked;
+    public long getImageSizeQuotaUseHttpHead(APIAddImageMsg msg){
+        long imageSizeAsked = 0;
         String url = msg.getUrl();
         url = url.trim();
-
         if (url.startsWith("file:///")) {
             GetImageSizeOnBackupStorageMsg cmsg = new GetImageSizeOnBackupStorageMsg();
             cmsg.setBackupStorageUuid(msg.getBackupStorageUuids().get(0));
@@ -111,27 +119,16 @@ public class ImageQuotaUtil {
 
             imageSizeAsked = ((GetImageSizeOnBackupStorageReply) reply).getSize();
         } else if (url.startsWith("http") || url.startsWith("https")) {
-            String len;
+            String len = null;
+            HttpHeaders header = restf.getRESTTemplate().headForHeaders(url);
             try {
-                HttpHeaders header = restf.getRESTTemplate().headForHeaders(url);
                 len = header.getFirst("Content-Length");
             } catch (Exception e) {
                 logger.warn(String.format("cannot get image.  The image url : %s. description: %s.name: %s",
                         url, msg.getDescription(), msg.getName()));
-                return;
             }
-
             imageSizeAsked = len == null ? 0 : Long.valueOf(len);
-        } else {
-            // bypass the check
-            imageSizeAsked = 0;
         }
-
-        if ((imageSizeQuota == 0) || (imageSizeUsed + imageSizeAsked > imageSizeQuota)) {
-            throw new ApiMessageInterceptionException(errf.instantiateErrorCode(IdentityErrors.QUOTA_EXCEEDING,
-                    String.format("quota exceeding. The account[uuid: %s] exceeds a quota[name: %s, value: %s]",
-                            msg.getSession().getAccountUuid(), ImageConstant.QUOTA_IMAGE_SIZE, imageSizeQuota)
-            ));
-        }
+        return imageSizeAsked;
     }
 }


### PR DESCRIPTION
for https://github.com/zstackio/issues/issues/2323
没有Case，因为`checkImageSizeQuotaUseHttpHead`上有`@BypassWhenUnitTest`的注解。

这里贴出了写的case：https://github.com/camilesing/zstack/commit/a8e7c1f2b307737c27317b97433d3c31d35e2b82

case中通过file:///开头的镜像成功hook住并模拟大小，结果可以跑过。