### PR TITLE
check smp has been added by other smp

### DIFF
--- a/header/src/main/java/org/zstack/header/errorcode/ErrorCode.java
+++ b/header/src/main/java/org/zstack/header/errorcode/ErrorCode.java
@@ -6,6 +6,7 @@ import org.zstack.utils.gson.JSONObjectUtil;
 import java.io.Serializable;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Objects;
 
 public class ErrorCode implements Serializable, Cloneable {
     private String code;
@@ -141,5 +142,35 @@ public class ErrorCode implements Serializable, Cloneable {
         }
 
         return false;
+    }
+
+    @Override
+    public boolean equals(Object t) {
+        if (this == t){
+            return true;
+        }
+        if (!(t instanceof ErrorCode)){
+            return false;
+        }
+
+        ErrorCode other = (ErrorCode)t;
+        return Objects.equals(this.code, other.code) &&
+                // might has endless loop
+                Objects.equals(this.cause, other.cause) &&
+                Objects.equals(this.details, other.details) &&
+                Objects.equals(this.opaque, other.opaque);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = 17;
+        result = result * 31 + (code == null ? 0 : code.hashCode());
+        //TODO: might has endless loop
+        //result = result * 31 + (cause == null || cause.details == null ? 0 : cause.details.hashCode());
+        result = result * 31 + (cause == null ? 0 : cause.hashCode());
+        result = result * 31 + (details == null ? 0 : details.hashCode());
+        result = result * 31 + (opaque == null ? 0 : opaque.hashCode());
+
+        return result;
     }
 }

--- a/header/src/main/java/org/zstack/header/errorcode/ErrorCodeList.java
+++ b/header/src/main/java/org/zstack/header/errorcode/ErrorCodeList.java
@@ -3,6 +3,7 @@ package org.zstack.header.errorcode;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * Created by xing5 on 2016/4/19.
@@ -16,5 +17,39 @@ public class ErrorCodeList extends ErrorCode {
 
     public void setCauses(List<ErrorCode> causes) {
         this.causes = causes;
+    }
+
+
+    /**
+     *
+     * @param t
+     * @return if the causes of the two objects both have no value,
+     * even the other object is not ErrorCodeList but ErrorCode,
+     * return true.
+     * if not compare their values.
+     */
+
+    @Override
+    public boolean equals(Object t) {
+        if(super.equals(t)){
+            if(t instanceof ErrorCodeList){
+                ErrorCodeList other = (ErrorCodeList)t;
+                if((this.causes == null && other.causes.isEmpty()) || this.causes.isEmpty() && other.causes == null){
+                    return true;
+                } else {
+                    return Objects.equals(this.causes, other.causes);
+                }
+            }
+            return causes == null || causes.isEmpty();
+        }
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result = result * 31 + (causes == null ? 0 : causes.hashCode());
+
+        return result;
     }
 }


### PR DESCRIPTION
 for https://github.com/zstackio/issues/issues/884

基本思路是增加一个 id file
connect 的时候将已有的所有 SMP uuids 带到 agent 上，由 agent 决定是不是被其他 SMP 占用

此外重写了 ErrorCode 的 hashcode 和 equals，以达到 errorCodes 可以不重复的显示给用户的目的
但此处重写还需斟酌下写法，因为严格意义上讲：因为 ErrorCode 有一个 ErrorCode 类型的 cause 成员变量， 严格 hash / equal 可能会导致 endless loop （两者互为 cause）