### PR TITLE
set spring RestTemplate charset to utf-8

### DIFF
--- a/core/src/main/java/org/zstack/core/rest/RESTFacadeImpl.java
+++ b/core/src/main/java/org/zstack/core/rest/RESTFacadeImpl.java
@@ -320,6 +320,8 @@ public class RESTFacadeImpl implements RESTFacade {
             requestHeaders.setContentLength(body.length());
             requestHeaders.set(RESTConstant.TASK_UUID, taskUuid);
             requestHeaders.set(RESTConstant.CALLBACK_URL, callbackUrl);
+            MediaType JSON = MediaType.parseMediaType("application/json; charset=utf-8");
+            requestHeaders.setContentType(JSON);
 
             if (headers != null) {
                 for (Map.Entry<String, String> e : headers.entrySet()) {


### PR DESCRIPTION
管理节点调用host agent，参数有中文时，angent中收到中文为乱码（RestTemplate 默认字符为 ISO-8859-1）