### PR TITLE
fix the hosts that are not enabled or connected should not be included…

### DIFF
--- a/compute/src/main/java/org/zstack/compute/allocator/HostCapacityReserveManagerImpl.java
+++ b/compute/src/main/java/org/zstack/compute/allocator/HostCapacityReserveManagerImpl.java
@@ -335,6 +335,8 @@ public class HostCapacityReserveManagerImpl implements HostCapacityReserveManage
         SimpleQuery<HostVO> q = dbf.createQuery(HostVO.class);
         q.select(HostVO_.uuid);
         q.add(HostVO_.zoneUuid, Op.IN, zoneUuids);
+        q.add(HostVO_.state, Op.EQ, HostState.Enabled);
+        q.add(HostVO_.status, Op.EQ, HostStatus.Connected);
         List<String> huuids = q.listValue();
         if (huuids.isEmpty()) {
             return ret;
@@ -360,6 +362,8 @@ public class HostCapacityReserveManagerImpl implements HostCapacityReserveManage
         SimpleQuery<HostVO> q = dbf.createQuery(HostVO.class);
         q.select(HostVO_.uuid);
         q.add(HostVO_.clusterUuid, Op.IN, clusterUuids);
+        q.add(HostVO_.state, Op.EQ, HostState.Enabled);
+        q.add(HostVO_.status, Op.EQ, HostStatus.Connected);
         List<String> huuids = q.listValue();
         if (huuids.isEmpty()) {
             return ret;


### PR DESCRIPTION
fix the hosts that are not enabled or connected should not be included when calculating reserved capacity by cluster or zone if the tag 'HostAllocatorGlobalConfig.HOST_LEVEL_RESERVE_CAPACITY' is true.