### PR TITLE
Update RESTApiFacadeImpl.java

### DIFF
--- a/core/src/main/java/org/zstack/core/rest/RESTApiFacadeImpl.java
+++ b/core/src/main/java/org/zstack/core/rest/RESTApiFacadeImpl.java
@@ -112,9 +112,7 @@ public class RESTApiFacadeImpl extends AbstractService implements RESTApiFacade,
             }
         }
 
-        for (APIEvent e : boundEvents) {
-            bus.subscribeEvent(this, e);
-        }
+        bus.subscribeEvent(this, boundEvents.toArray(new APIEvent[boundEvents.size()]));
     }
 
     private static int initMaxRestResultLength() {


### PR DESCRIPTION
订阅事件接口可以传入事件数组，为什么要用循环调用？使用循环调用会使这些相同类型的事件被订阅到不同的事件处理wrapper对象，导致每个异步api的返回事件都会重复300多次调用这个文件中的handleEvent()。