### PR TITLE
Fix bugs in RESTFacadeImpl.java

### DIFF
--- a/core/src/main/java/org/zstack/core/rest/RESTFacadeImpl.java
+++ b/core/src/main/java/org/zstack/core/rest/RESTFacadeImpl.java
@@ -205,7 +205,7 @@ public class RESTFacadeImpl implements RESTFacade {
             HttpEntity<String> entity = this.httpServletRequestToHttpEntity(req);
             if (commandPath == null) {
                 rsp.sendError(HttpStatus.SC_BAD_REQUEST, "No 'commandPath' found in the header");
-                logger.warn(String.format("Received a command, but no 'taskUuid' found in headers. request body: %s", entity.getBody()));
+                logger.warn(String.format("Received a command, but no 'commandPath' found in headers. request body: %s", entity.getBody()));
                 return;
             }
 


### PR DESCRIPTION
Hi,
It's an incremental PR that fixes a bug in the logging statement.
The logging statement was updated to correctly reflect the variable being checked ('commandPath') instead of 'taskUuid', ensuring consistency between the static logging text and the dynamic variable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Updated the logging message for better clarity when a `commandPath` is not found in request headers, improving error reporting.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->